### PR TITLE
Slugified the Article Title (API)

### DIFF
--- a/api/article/models.py
+++ b/api/article/models.py
@@ -120,10 +120,9 @@ def clean(self):
 
     if isinstance(self.instance, ArticlePage):
         title = cleaned_data.get("title", None)
+        slug = cleaned_data.get("slug", None)
 
         if title:
-            slug = cleaned_data["slug"]
-
             cleaned_data["slug"] = unique_slug_generator(
                 instance=self.instance, new_slug=slug
             )

--- a/api/article/models.py
+++ b/api/article/models.py
@@ -1,5 +1,8 @@
 from django import forms
 from django.db import models
+from django.db.models.signals import pre_save
+
+from core.utils import slug_generator_receiver
 
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey, ParentalManyToManyField
@@ -105,3 +108,6 @@ class ArticlePage(Page):
         ),
         StreamFieldPanel("body"),
     ]
+
+
+pre_save.connect(slug_generator_receiver, sender=ArticlePage)

--- a/api/article/models.py
+++ b/api/article/models.py
@@ -1,8 +1,7 @@
 from django import forms
 from django.db import models
-from django.db.models.signals import pre_save
 
-from core.utils import slug_generator_receiver
+from core.utils import unique_slug_generator
 
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey, ParentalManyToManyField
@@ -109,5 +108,10 @@ class ArticlePage(Page):
         StreamFieldPanel("body"),
     ]
 
+    def full_clean(self, *args, **kwargs):
+        super(ArticlePage, self).full_clean(*args, **kwargs)
 
-pre_save.connect(slug_generator_receiver, sender=ArticlePage)
+        if self.title:
+            current_slug = None if not self.slug else self.slug
+
+            self.slug = unique_slug_generator(instance=self, new_slug=current_slug)

--- a/api/core/utils.py
+++ b/api/core/utils.py
@@ -41,3 +41,13 @@ def unique_slug_generator(instance, new_slug=None):
         return unique_slug_generator(instance, new_slug=unique_slug)
 
     return slug
+
+
+def slug_generator_receiver(sender, instance, *args, **kwargs):
+    """
+    A receiver function for the signal dispatcher to convert the slug whether or not a
+    slug was given as an input from the user.
+    """
+    current_slug = None if not instance.slug else instance.slug
+
+    instance.slug = unique_slug_generator(instance=instance, new_slug=current_slug)

--- a/api/core/utils.py
+++ b/api/core/utils.py
@@ -41,13 +41,3 @@ def unique_slug_generator(instance, new_slug=None):
         return unique_slug_generator(instance, new_slug=unique_slug)
 
     return slug
-
-
-def slug_generator_receiver(sender, instance, *args, **kwargs):
-    """
-    A receiver function for the signal dispatcher to convert the slug whether or not a
-    slug was given as an input from the user.
-    """
-    current_slug = None if not instance.slug else instance.slug
-
-    instance.slug = unique_slug_generator(instance=instance, new_slug=current_slug)

--- a/api/core/utils.py
+++ b/api/core/utils.py
@@ -1,0 +1,43 @@
+import random
+import string
+
+from django.utils.text import slugify
+
+
+def random_string_generator(
+    string_size=10, chars=string.ascii_lowercase + string.digits
+):
+    """
+    Generates a random string with a default of size of 10.
+    """
+    return "".join(random.choice(chars) for _ in range(string_size))
+
+
+def unique_slug_generator(instance, new_slug=None):
+    """
+    Assumes the instance has a model with a slug field and a title field for Wagtail's
+    higher-level model `Page`.
+
+    Returns: Unique slug from the model's title if the slug query exists in the DB, or the
+    newly created slug that slugifies the model's title if the slug query does not exist in
+    the DB.
+    """
+    if new_slug is not None:
+        slug = new_slug
+    else:
+        slug = slugify(instance.title)
+
+    model = instance.__class__
+    query_exists = model.objects.filter(slug=slug).exists()
+
+    if query_exists:
+        unique_slug = "{slug}-{random_string}".format(
+            slug=slug, random_string=random_string_generator(string_size=4)
+        )
+
+        # Run this function again to check if the uniquely random slug is truly unique
+        # in the DB. If it is unique, return the unique slug. Otherwise, generate
+        # another unique slug.
+        return unique_slug_generator(instance, new_slug=unique_slug)
+
+    return slug


### PR DESCRIPTION
## Changes
1. Created custom slug generator utility functions to be used on creating unique slugs whether or not they exist in the DB.
2. Override the `WagtailAdminModelForm` `clean` and `full_clean` methods to make the unique slug generator to work.

## Purpose
There needs to be a custom slug generator that would uniquely create a slug if the name of the article exists in the database, or return the slugified article's name if it does not exist in the database. This should occur before the article gets validated from saving, and it should work whether or not the user has input a name for the title's slug in the Wagtail panel (but the page title needs to not be empty).

Closes #52 