### PR TITLE
Created a Custom Base Query for Redux Toolkit (Web)

### DIFF
--- a/web/src/common/api/coreSplitApi.ts
+++ b/web/src/common/api/coreSplitApi.ts
@@ -1,0 +1,16 @@
+import { createApi } from '@reduxjs/toolkit/query/react';
+
+import customBaseQuery from './customBaseQuery';
+
+export default createApi({
+  reducerPath: 'articleApi',
+  baseQuery: customBaseQuery,
+
+  keepUnusedDataFor: 0,
+  refetchOnMountOrArgChange: true,
+  refetchOnReconnect: true,
+
+  tagTypes: ['Article', 'Category', 'Tag'],
+
+  endpoints: () => ({}),
+});

--- a/web/src/common/api/customBaseQuery.ts
+++ b/web/src/common/api/customBaseQuery.ts
@@ -1,0 +1,22 @@
+import {
+  BaseQueryFn,
+  FetchArgs,
+  fetchBaseQuery,
+  FetchBaseQueryError,
+} from '@reduxjs/toolkit/dist/query';
+
+const baseQuery = fetchBaseQuery({
+  baseUrl: 'http://127.0.0.1:8000/api/v1',
+});
+
+const customBaseQuery: BaseQueryFn<
+  FetchArgs | string,
+  unknown,
+  FetchBaseQueryError
+> = async (args, api, extraOptions) => {
+  const result = await baseQuery(args, api, extraOptions);
+
+  return result;
+};
+
+export default customBaseQuery;


### PR DESCRIPTION
## Changes
1. Created a custom base query that would be used throughout the web app.
2. Initialized a `createApi` with the custom base query that targets the Django API, and that would be used to split different endpoints on the same API.

## Purpose
A custom base query needs to be created before making any RTK APIs so that it could be reused.

Closes #60 