### PR TITLE
Created Tags API with RTK (Web)

### DIFF
--- a/web/src/common/api/tagExtendedApi.ts
+++ b/web/src/common/api/tagExtendedApi.ts
@@ -1,0 +1,27 @@
+import { IPaginationResponse, ITag } from 'common/models';
+
+import coreSplitApi from './coreSplitApi';
+
+const fieldsParams = '_,id,name,slug';
+
+type TGetTagsRespone = IPaginationResponse & {
+  items: ITag[];
+};
+
+const tagExtendedApi = coreSplitApi.injectEndpoints({
+  endpoints: (builder) => ({
+    getTags: builder.query<TGetTagsRespone, void>({
+      query: () => ({ url: `/tags/?fields=${fieldsParams}` }),
+      providesTags: ['Tag'],
+    }),
+
+    getTagById: builder.query<ITag, number>({
+      query: (id) => ({ url: `/tags/${id}/?fields=${fieldsParams}` }),
+      providesTags: ['Tag'],
+    }),
+  }),
+
+  overrideExisting: false,
+});
+
+export const { useGetTagByIdQuery, useGetTagsQuery } = tagExtendedApi;

--- a/web/src/common/models/index.ts
+++ b/web/src/common/models/index.ts
@@ -1,2 +1,3 @@
 export * from './category';
 export * from './response';
+export * from './tag';

--- a/web/src/common/models/tag.ts
+++ b/web/src/common/models/tag.ts
@@ -1,0 +1,5 @@
+export interface ITag {
+  id: number;
+  name: string;
+  slug: string;
+}


### PR DESCRIPTION
## Changes
1. Created an RTK API for tags along with interface models to be used throughout the web app.

## Purpose
There should be an RTK API that gets the tags from the Django server.

Closes #63 