### PR TITLE
Created Related Articles Sidebar for Article Detail Page (Web)

### DIFF
--- a/web/src/common/api/articleExtendedApi.ts
+++ b/web/src/common/api/articleExtendedApi.ts
@@ -25,6 +25,17 @@ type TGetArticlesResponse = IPaginationResponse & {
   items: TGetArticles[];
 };
 
+type TGetArticlesByRelatedCategory = Pick<
+  IArticle,
+  'header_image' | 'id' | 'title' | 'uuid'
+> & {
+  meta: Pick<IArticle['meta'], 'slug'>;
+};
+
+type TGetArticlesByRelatedCategoryResponse = IPaginationResponse & {
+  items: TGetArticlesByRelatedCategory[];
+};
+
 const articleExtendedApi = coreSplitApi.injectEndpoints({
   endpoints: (builder) => ({
     getArticles: builder.query<TGetArticlesResponse, TGetArticlesRequest>({
@@ -54,6 +65,16 @@ const articleExtendedApi = coreSplitApi.injectEndpoints({
     getArticleById: builder.query<IArticle, number>({
       query: (id) => ({
         url: `/pages/${id}/?fields=_,id,uuid,title,slug,description,header_image,body,tags,categories,seo_title,search_description,first_published_at,reading_time`,
+      }),
+      providesTags: ['Article'],
+    }),
+
+    getArticlesByRelatedCategory: builder.query<
+      TGetArticlesByRelatedCategoryResponse,
+      number
+    >({
+      query: (categoryId) => ({
+        url: `/pages/?type=article.ArticlePage&fields=_,id,uuid,title,slug,header_image&categories=${categoryId}&limit=5`,
       }),
       providesTags: ['Article'],
     }),

--- a/web/src/common/api/articleExtendedApi.ts
+++ b/web/src/common/api/articleExtendedApi.ts
@@ -83,5 +83,8 @@ const articleExtendedApi = coreSplitApi.injectEndpoints({
   overrideExisting: false,
 });
 
-export const { useGetArticleByIdQuery, useGetArticlesQuery } =
-  articleExtendedApi;
+export const {
+  useGetArticleByIdQuery,
+  useGetArticlesByRelatedCategoryQuery,
+  useGetArticlesQuery,
+} = articleExtendedApi;

--- a/web/src/common/components/GeneralSidebar/index.tsx
+++ b/web/src/common/components/GeneralSidebar/index.tsx
@@ -4,15 +4,19 @@ import { Sidebar, SidebarContainer } from './styles';
 
 export interface IGeneralSidebar {
   sidebarClassName?: string;
+  sidebarContainerClassName?: string;
   sidebarContentElement: JSX.Element | JSX.Element[];
 }
 
 const GeneralSidebar: FC<IGeneralSidebar> = ({
   sidebarClassName,
+  sidebarContainerClassName,
   sidebarContentElement,
 }) => (
   <Sidebar className={sidebarClassName ?? ''}>
-    <SidebarContainer>{sidebarContentElement}</SidebarContainer>
+    <SidebarContainer className={sidebarContainerClassName ?? ''}>
+      {sidebarContentElement}
+    </SidebarContainer>
   </Sidebar>
 );
 

--- a/web/src/common/components/GeneralSidebar/styles.ts
+++ b/web/src/common/components/GeneralSidebar/styles.ts
@@ -10,7 +10,7 @@ export const Sidebar = styled.aside`
 
   &.related-sidebar {
     top: 30rem;
-    right: 24rem;
+    right: 14rem;
   }
 `;
 
@@ -20,6 +20,6 @@ export const SidebarContainer = styled.div`
   }
 
   &.related-sidebar {
-    width: 20rem;
+    width: 35rem;
   }
 `;

--- a/web/src/common/components/GeneralSidebar/styles.ts
+++ b/web/src/common/components/GeneralSidebar/styles.ts
@@ -1,14 +1,14 @@
 import styled from 'styled-components';
 
 export const Sidebar = styled.aside`
-  position: fixed;
-
   &.filter-sidebar {
+    position: fixed;
     top: 30rem;
     left: 24rem;
   }
 
   &.related-sidebar {
+    position: absolute;
     top: 30rem;
     right: 14rem;
   }

--- a/web/src/common/components/GeneralSidebar/styles.ts
+++ b/web/src/common/components/GeneralSidebar/styles.ts
@@ -15,5 +15,11 @@ export const Sidebar = styled.aside`
 `;
 
 export const SidebarContainer = styled.div`
-  width: 15rem;
+  &.filter-sidebar {
+    width: 15rem;
+  }
+
+  &.related-sidebar {
+    width: 20rem;
+  }
 `;

--- a/web/src/common/components/GlassCircle/index.tsx
+++ b/web/src/common/components/GlassCircle/index.tsx
@@ -2,10 +2,12 @@ import React, { FC } from 'react';
 
 import { GlassContainer, GlassImage, GlassImageWrapper } from './styles';
 
-interface IGlassCirlce {
+export interface IGlassCirlce {
+  glassContainerClassName?: string;
   glassDarkShadowBlur: number;
   glassDarkShadowHorizontalOffset: number;
   glassDarkShadowVerticalOffset: number;
+  glassImageWrapperClassName?: string;
   glassLightShadowBlur: number;
   glassLightShadowHorizontalOffset: number;
   glassLightShadowVerticalOffset: number;
@@ -15,9 +17,11 @@ interface IGlassCirlce {
 }
 
 const GlassCircle: FC<IGlassCirlce> = ({
+  glassContainerClassName,
   glassDarkShadowBlur,
   glassDarkShadowHorizontalOffset,
   glassDarkShadowVerticalOffset,
+  glassImageWrapperClassName,
   glassLightShadowBlur,
   glassLightShadowHorizontalOffset,
   glassLightShadowVerticalOffset,
@@ -32,8 +36,9 @@ const GlassCircle: FC<IGlassCirlce> = ({
     boxLightShadowBlur={glassLightShadowBlur}
     boxLightShadowHorizontalOffset={glassLightShadowHorizontalOffset}
     boxLightShadowVerticalOffset={glassLightShadowVerticalOffset}
+    className={glassContainerClassName}
   >
-    <GlassImageWrapper opacity={opacity}>
+    <GlassImageWrapper className={glassImageWrapperClassName} opacity={opacity}>
       <GlassImage src={imageSrc} alt={imageAlt} />
     </GlassImageWrapper>
   </GlassContainer>

--- a/web/src/common/components/GlassCircle/styles.ts
+++ b/web/src/common/components/GlassCircle/styles.ts
@@ -33,6 +33,11 @@ export const GlassContainer = styled.div<IGlassContainer>`
     ${`${props.boxDarkShadowBlur}rem` ?? '0'} 0 rgba(${
     props.theme.colors.glassDarkShadow.rgb
   }, 0.27)`};
+
+  &.related-sidebar {
+    width: 10rem;
+    height: 10rem;
+  }
 `;
 
 export const GlassImageWrapper = styled.div<IGlassImageWrapper>`
@@ -45,6 +50,11 @@ export const GlassImageWrapper = styled.div<IGlassImageWrapper>`
   border-radius: 50%;
   opacity: ${({ opacity }) => opacity ?? '1'};
   overflow: hidden;
+
+  &.related-sidebar {
+    width: 9rem;
+    height: 9rem;
+  }
 `;
 
 export const GlassImage = styled.img`

--- a/web/src/common/components/GlassCircle/styles.ts
+++ b/web/src/common/components/GlassCircle/styles.ts
@@ -35,8 +35,8 @@ export const GlassContainer = styled.div<IGlassContainer>`
   }, 0.27)`};
 
   &.related-sidebar {
-    width: 10rem;
-    height: 10rem;
+    width: 8.5rem;
+    height: 8.5rem;
   }
 `;
 
@@ -52,8 +52,8 @@ export const GlassImageWrapper = styled.div<IGlassImageWrapper>`
   overflow: hidden;
 
   &.related-sidebar {
-    width: 9rem;
-    height: 9rem;
+    width: 7.5rem;
+    height: 7.5rem;
   }
 `;
 

--- a/web/src/features/article/components/ArticleDetail/index.tsx
+++ b/web/src/features/article/components/ArticleDetail/index.tsx
@@ -1,12 +1,11 @@
-import React, { FC, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import React, { FC } from 'react';
 
 import noImage from 'assets/img/no-image.png';
 import twitterIconBlack from 'assets/img/twitter-logo_black.png';
 
-import { useGetArticleByIdQuery } from 'common/api/articleExtendedApi';
-
 import GlassRectangle from 'common/components/GlassRectangle';
+
+import { IArticle } from 'common/models';
 
 import HeadingPrimary from 'common/typography/HeadingPrimary';
 import Paragraph from 'common/typography/Paragraph';
@@ -32,137 +31,101 @@ import {
   AuthorTwitterLink,
 } from './styles';
 
-type TArticleParams = {
-  articleId: string;
-};
+interface IArticleDetail {
+  articleData: IArticle;
+}
 
-const ArticleDetail: FC = () => {
-  const [doNotInitiateQuery, setDoNotInitiateQuery] = useState<boolean>(true);
-  const { articleId } = useParams<TArticleParams>();
+const ArticleDetail: FC<IArticleDetail> = ({ articleData }) => (
+  <Article className="navbar-footer-space">
+    <ArticleAdditionalInfo>
+      <ArticleCategory>
+        <Paragraph>{articleData.categories[0].name}</Paragraph>
+      </ArticleCategory>
 
-  const {
-    data: articleData,
-    isError,
-    isFetching,
-    isSuccess,
-  } = useGetArticleByIdQuery(articleId ? parseInt(articleId, 10) : 0, {
-    skip: doNotInitiateQuery,
-  });
+      <ArticleTags>
+        {articleData.tags.length > 0 &&
+          articleData.tags.map((tag) => (
+            <Paragraph key={`${tag.slug}-${tag.id}`}>{tag.name}</Paragraph>
+          ))}
+      </ArticleTags>
+    </ArticleAdditionalInfo>
 
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      if (articleId) {
-        setDoNotInitiateQuery(false);
-      }
-    }, 1000);
+    <ArticleTitle>
+      <HeadingPrimary>{articleData.title}</HeadingPrimary>
+    </ArticleTitle>
 
-    return () => clearTimeout(timer);
-  }, [articleId]);
+    <ArticleAuthor>
+      <Paragraph>Elias Gutierrez</Paragraph>
+    </ArticleAuthor>
 
-  if (isFetching) {
-    return <HeadingPrimary>Fetching!</HeadingPrimary>;
-  }
-
-  if (isError) {
-    return <HeadingPrimary>Error!</HeadingPrimary>;
-  }
-
-  if (isSuccess && !articleData) {
-    return <HeadingPrimary>There is no article.</HeadingPrimary>;
-  }
-
-  return articleData ? (
-    <Article className="navbar-footer-space">
-      <ArticleAdditionalInfo>
-        <ArticleCategory>
-          <Paragraph>{articleData.categories[0].name}</Paragraph>
-        </ArticleCategory>
-
-        <ArticleTags>
-          {articleData.tags.length > 0 &&
-            articleData.tags.map((tag) => (
-              <Paragraph key={`${tag.slug}-${tag.id}`}>{tag.name}</Paragraph>
-            ))}
-        </ArticleTags>
-      </ArticleAdditionalInfo>
-
-      <ArticleTitle>
-        <HeadingPrimary>{articleData.title}</HeadingPrimary>
-      </ArticleTitle>
-
-      <ArticleAuthor>
-        <Paragraph>Elias Gutierrez</Paragraph>
-      </ArticleAuthor>
-
-      <AuthorTwitterContainer>
-        <AuthorTwitterIconWrapper>
-          <AuthorTwitterIcon
-            src={twitterIconBlack}
-            alt="Twitter Logo"
-            title="Follow Elias Gutierrez on Twitter"
-          />
-        </AuthorTwitterIconWrapper>
-
-        <AuthorTwitterLink
-          href="https://twitter.com/_BlackCubes_"
-          target="_blank"
-          rel="noopener"
-        >
-          @_BlackCubes_
-        </AuthorTwitterLink>
-      </AuthorTwitterContainer>
-
-      <ArticleAdditionalInfo>
-        <ArticleDate>
-          <Paragraph>
-            {dateFormat('en-US', articleData.meta.first_published_at)}
-          </Paragraph>
-        </ArticleDate>
-
-        <ArticleReadTime>
-          <Paragraph>
-            {articleData.reading_time < 60
-              ? `${Math.round(articleData.reading_time)} sec`
-              : `${Math.floor(articleData.reading_time / 60)} min`}
-            &nbsp;read
-          </Paragraph>
-        </ArticleReadTime>
-      </ArticleAdditionalInfo>
-
-      <ArticleDescription>
-        <Paragraph>{articleData.description}</Paragraph>
-      </ArticleDescription>
-
-      <ArticleHeaderImage>
-        <GlassRectangle
-          customClassName="article-detail-page__header-image"
-          glassDarkShadowBlur={0.4}
-          glassDarkShadowHorizontalOffset={0.3}
-          glassDarkShadowVerticalOffset={0.3}
-          glassLightShadowBlur={0.4}
-          glassLightShadowHorizontalOffset={-0.3}
-          glassLightShadowVerticalOffset={-0.3}
-          imageAlt="Header image for article"
-          imageSrc={
-            articleData.header_image
-              ? `http://localhost:8000${articleData.header_image}`
-              : noImage
-          }
-          opacity={1}
+    <AuthorTwitterContainer>
+      <AuthorTwitterIconWrapper>
+        <AuthorTwitterIcon
+          src={twitterIconBlack}
+          alt="Twitter Logo"
+          title="Follow Elias Gutierrez on Twitter"
         />
-      </ArticleHeaderImage>
+      </AuthorTwitterIconWrapper>
 
-      <ArticleBodyContainer>
-        {articleData.body.map((body) => (
-          <ArticleBody
-            key={body.id}
-            bodyType={body.type}
-            bodyValue={body.value}
-          />
-        ))}
-      </ArticleBodyContainer>
-    </Article>
-  ) : null;
-};
+      <AuthorTwitterLink
+        href="https://twitter.com/_BlackCubes_"
+        target="_blank"
+        rel="noopener"
+      >
+        @_BlackCubes_
+      </AuthorTwitterLink>
+    </AuthorTwitterContainer>
+
+    <ArticleAdditionalInfo>
+      <ArticleDate>
+        <Paragraph>
+          {dateFormat('en-US', articleData.meta.first_published_at)}
+        </Paragraph>
+      </ArticleDate>
+
+      <ArticleReadTime>
+        <Paragraph>
+          {articleData.reading_time < 60
+            ? `${Math.round(articleData.reading_time)} sec`
+            : `${Math.floor(articleData.reading_time / 60)} min`}
+          &nbsp;read
+        </Paragraph>
+      </ArticleReadTime>
+    </ArticleAdditionalInfo>
+
+    <ArticleDescription>
+      <Paragraph>{articleData.description}</Paragraph>
+    </ArticleDescription>
+
+    <ArticleHeaderImage>
+      <GlassRectangle
+        customClassName="article-detail-page__header-image"
+        glassDarkShadowBlur={0.4}
+        glassDarkShadowHorizontalOffset={0.3}
+        glassDarkShadowVerticalOffset={0.3}
+        glassLightShadowBlur={0.4}
+        glassLightShadowHorizontalOffset={-0.3}
+        glassLightShadowVerticalOffset={-0.3}
+        imageAlt="Header image for article"
+        imageSrc={
+          articleData.header_image
+            ? `http://localhost:8000${articleData.header_image}`
+            : noImage
+        }
+        opacity={1}
+      />
+    </ArticleHeaderImage>
+
+    <ArticleBodyContainer>
+      {articleData.body.map((body) => (
+        <ArticleBody
+          key={body.id}
+          bodyType={body.type}
+          bodyValue={body.value}
+        />
+      ))}
+    </ArticleBodyContainer>
+  </Article>
+);
 
 export default ArticleDetail;

--- a/web/src/features/article/components/FilterSidebar/index.tsx
+++ b/web/src/features/article/components/FilterSidebar/index.tsx
@@ -56,6 +56,7 @@ const FilterSidebar: FC<IFilterSidebar> = ({
   return (
     <GeneralSidebar
       sidebarClassName="filter-sidebar"
+      sidebarContainerClassName="filter-sidebar"
       sidebarContentElement={
         <>
           <ClearFilter>

--- a/web/src/features/article/components/RelatedSidebar/index.tsx
+++ b/web/src/features/article/components/RelatedSidebar/index.tsx
@@ -30,10 +30,12 @@ type TRelatedArticle = Pick<
 };
 
 interface IRelatedSidebar {
-  relatedArticlesByCategory: TRelatedArticle[];
+  relatedArticlesByCategoryData: TRelatedArticle[];
 }
 
-const RelatedSidebar: FC<IRelatedSidebar> = ({ relatedArticlesByCategory }) => (
+const RelatedSidebar: FC<IRelatedSidebar> = ({
+  relatedArticlesByCategoryData,
+}) => (
   <GeneralSidebar
     sidebarClassName="related-sidebar"
     sidebarContentElement={
@@ -44,7 +46,7 @@ const RelatedSidebar: FC<IRelatedSidebar> = ({ relatedArticlesByCategory }) => (
 
         <SidebarContainer>
           <SidebarList>
-            {relatedArticlesByCategory.map((relatedArticle) => (
+            {relatedArticlesByCategoryData.map((relatedArticle) => (
               <RelatedItem key={relatedArticle.uuid}>
                 <RelatedLink to={`/articles/${relatedArticle.id}`}>
                   <RelatedContainer>

--- a/web/src/features/article/components/RelatedSidebar/index.tsx
+++ b/web/src/features/article/components/RelatedSidebar/index.tsx
@@ -38,6 +38,7 @@ const RelatedSidebar: FC<IRelatedSidebar> = ({
 }) => (
   <GeneralSidebar
     sidebarClassName="related-sidebar"
+    sidebarContainerClassName="related-sidebar"
     sidebarContentElement={
       <>
         <SidebarTitle>

--- a/web/src/features/article/components/RelatedSidebar/index.tsx
+++ b/web/src/features/article/components/RelatedSidebar/index.tsx
@@ -1,0 +1,83 @@
+import React, { FC } from 'react';
+
+import noImage from 'assets/img/no-image.png';
+
+import GeneralSidebar from 'common/components/GeneralSidebar';
+
+import GlassCircle from 'common/components/GlassCircle';
+
+import { IArticle } from 'common/models';
+
+import HeadingTertiary from 'common/typography/HeadingTertiary';
+
+import {
+  RelatedContainer,
+  RelatedImageWrapper,
+  RelatedItem,
+  RelatedLink,
+  RelatedTitle,
+  RelatedTitleWrapper,
+  SidebarContainer,
+  SidebarList,
+  SidebarTitle,
+} from './styles';
+
+type TRelatedArticle = Pick<
+  IArticle,
+  'header_image' | 'id' | 'title' | 'uuid'
+> & {
+  meta: Pick<IArticle['meta'], 'slug'>;
+};
+
+interface IRelatedSidebar {
+  relatedArticlesByCategory: TRelatedArticle[];
+}
+
+const RelatedSidebar: FC<IRelatedSidebar> = ({ relatedArticlesByCategory }) => (
+  <GeneralSidebar
+    sidebarClassName="related-sidebar"
+    sidebarContentElement={
+      <>
+        <SidebarTitle>
+          <HeadingTertiary>Related Categories</HeadingTertiary>
+        </SidebarTitle>
+
+        <SidebarContainer>
+          <SidebarList>
+            {relatedArticlesByCategory.map((relatedArticle) => (
+              <RelatedItem key={relatedArticle.uuid}>
+                <RelatedLink to={`/articles/${relatedArticle.id}`}>
+                  <RelatedContainer>
+                    <RelatedImageWrapper>
+                      <GlassCircle
+                        glassDarkShadowBlur={0.2}
+                        glassDarkShadowHorizontalOffset={0.1}
+                        glassDarkShadowVerticalOffset={0.1}
+                        glassLightShadowBlur={0.2}
+                        glassLightShadowHorizontalOffset={-0.1}
+                        glassLightShadowVerticalOffset={-0.1}
+                        imageAlt={relatedArticle.title}
+                        imageSrc={
+                          relatedArticle.header_image
+                            ? `http://localhost:8000${relatedArticle.header_image}`
+                            : noImage
+                        }
+                        opacity={1}
+                      />
+                    </RelatedImageWrapper>
+
+                    <RelatedTitleWrapper>
+                      <RelatedTitle>{relatedArticle.title}</RelatedTitle>
+                    </RelatedTitleWrapper>
+                  </RelatedContainer>
+                </RelatedLink>
+              </RelatedItem>
+            ))}
+          </SidebarList>
+        </SidebarContainer>
+      </>
+    }
+  />
+);
+
+export default RelatedSidebar;

--- a/web/src/features/article/components/RelatedSidebar/index.tsx
+++ b/web/src/features/article/components/RelatedSidebar/index.tsx
@@ -42,7 +42,7 @@ const RelatedSidebar: FC<IRelatedSidebar> = ({
     sidebarContentElement={
       <>
         <SidebarTitle>
-          <HeadingTertiary>Related Categories</HeadingTertiary>
+          <HeadingTertiary>Related</HeadingTertiary>
         </SidebarTitle>
 
         <SidebarContainer>

--- a/web/src/features/article/components/RelatedSidebar/index.tsx
+++ b/web/src/features/article/components/RelatedSidebar/index.tsx
@@ -52,9 +52,11 @@ const RelatedSidebar: FC<IRelatedSidebar> = ({
                   <RelatedContainer>
                     <RelatedImageWrapper>
                       <GlassCircle
+                        glassContainerClassName="related-sidebar"
                         glassDarkShadowBlur={0.2}
                         glassDarkShadowHorizontalOffset={0.1}
                         glassDarkShadowVerticalOffset={0.1}
+                        glassImageWrapperClassName="related-sidebar"
                         glassLightShadowBlur={0.2}
                         glassLightShadowHorizontalOffset={-0.1}
                         glassLightShadowVerticalOffset={-0.1}

--- a/web/src/features/article/components/RelatedSidebar/styles.ts
+++ b/web/src/features/article/components/RelatedSidebar/styles.ts
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 // GENERAL
 export const SidebarTitle = styled.div`
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
 
   & h3 {
     font-size: 2rem;
@@ -20,10 +20,15 @@ export const SidebarList = styled.ul``;
 
 // RELATED
 export const RelatedItem = styled.li`
+  margin-bottom: 1.2rem;
+  padding-top: 0.4rem;
+  border-top: 0.1rem solid
+    ${(props) => `rgba(${props.theme.colors.secondary.rgb}, 0.9)`};
   list-style: none;
 
-  &:not(:last-child) {
-    margin-bottom: 1rem;
+  &:first-of-type {
+    padding-top: 0;
+    border-top: none;
   }
 `;
 

--- a/web/src/features/article/components/RelatedSidebar/styles.ts
+++ b/web/src/features/article/components/RelatedSidebar/styles.ts
@@ -39,9 +39,13 @@ export const RelatedContainer = styled.div`
   display: flex;
 `;
 
-export const RelatedImageWrapper = styled.div``;
+export const RelatedImageWrapper = styled.div`
+  margin-right: 1rem;
+`;
 
-export const RelatedTitleWrapper = styled.div``;
+export const RelatedTitleWrapper = styled.div`
+  padding-top: 1rem;
+`;
 
 export const RelatedTitle = styled.h4`
   font-size: 1.8rem;

--- a/web/src/features/article/components/RelatedSidebar/styles.ts
+++ b/web/src/features/article/components/RelatedSidebar/styles.ts
@@ -1,0 +1,50 @@
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+// GENERAL
+export const SidebarTitle = styled.div`
+  margin-bottom: 1rem;
+
+  & h3 {
+    font-size: 2rem;
+  }
+`;
+
+export const SidebarContainer = styled.div`
+  &:not(:last-child) {
+    margin-bottom: 3rem;
+  }
+`;
+
+export const SidebarList = styled.ul``;
+
+// RELATED
+export const RelatedItem = styled.li`
+  list-style: none;
+
+  &:not(:last-child) {
+    margin-bottom: 1rem;
+  }
+`;
+
+export const RelatedLink = styled(Link)`
+  text-decoration: none;
+
+  &:hover h4 {
+    text-decoration: underline;
+  }
+`;
+
+export const RelatedContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const RelatedImageWrapper = styled.div``;
+
+export const RelatedTitleWrapper = styled.div``;
+
+export const RelatedTitle = styled.h4`
+  font-size: 1.8rem;
+  color: ${(props) => props.theme.colors.primary.hex};
+`;

--- a/web/src/features/article/components/RelatedSidebar/styles.ts
+++ b/web/src/features/article/components/RelatedSidebar/styles.ts
@@ -44,10 +44,11 @@ export const RelatedImageWrapper = styled.div`
 `;
 
 export const RelatedTitleWrapper = styled.div`
-  padding-top: 1rem;
+  padding-top: 0.5rem;
 `;
 
 export const RelatedTitle = styled.h4`
-  font-size: 1.8rem;
+  font-size: 1.6rem;
   color: ${(props) => props.theme.colors.primary.hex};
+  font-weight: 500;
 `;

--- a/web/src/features/article/components/RelatedSidebar/styles.ts
+++ b/web/src/features/article/components/RelatedSidebar/styles.ts
@@ -37,7 +37,6 @@ export const RelatedLink = styled(Link)`
 
 export const RelatedContainer = styled.div`
   display: flex;
-  flex-direction: column;
 `;
 
 export const RelatedImageWrapper = styled.div``;

--- a/web/src/features/article/components/index.ts
+++ b/web/src/features/article/components/index.ts
@@ -1,3 +1,4 @@
 export { default as ArticleDetail } from './ArticleDetail';
 export { default as ArticleList } from './ArticleList';
 export { default as FilterSidebar } from './FilterSidebar';
+export { default as RelatedSidebar } from './RelatedSidebar';

--- a/web/src/features/article/pages/ArticleDetailView.tsx
+++ b/web/src/features/article/pages/ArticleDetailView.tsx
@@ -1,36 +1,73 @@
 import React, { FC, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
-import { useGetArticleByIdQuery } from 'common/api/articleExtendedApi';
+import {
+  useGetArticleByIdQuery,
+  useGetArticlesByRelatedCategoryQuery,
+} from 'common/api/articleExtendedApi';
 
-import { ArticleDetail } from 'features/article/components';
+import { ArticleDetail, RelatedSidebar } from 'features/article/components';
 
 type TArticleParams = {
   articleId: string;
 };
 
 const ArticleDetailView: FC = () => {
-  const [doNotInitiateQuery, setDoNotInitiateQuery] = useState<boolean>(true);
+  const [doNotInitiateArticleQuery, setDoNotInitiateArticleQuery] =
+    useState<boolean>(true);
+  const [
+    doNotInitiateRelatedArticlesQuery,
+    setDoNotInitiateRelatedArticlesQuery,
+  ] = useState<boolean>(true);
+
   const { articleId } = useParams<TArticleParams>();
+  const [categoryId, setCategoryId] = useState<number>(0);
 
   const { data: articleData } = useGetArticleByIdQuery(
     articleId ? parseInt(articleId, 10) : 0,
     {
-      skip: doNotInitiateQuery,
+      skip: doNotInitiateArticleQuery,
     }
   );
+  const { data: relatedArticlesByCategoryData } =
+    useGetArticlesByRelatedCategoryQuery(categoryId, {
+      skip: doNotInitiateRelatedArticlesQuery,
+    });
 
   useEffect(() => {
     const timer = setTimeout(() => {
       if (articleId) {
-        setDoNotInitiateQuery(false);
+        setDoNotInitiateArticleQuery(false);
       }
     }, 1000);
 
     return () => clearTimeout(timer);
   }, [articleId]);
 
-  return articleData ? <ArticleDetail articleData={articleData} /> : null;
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (articleData) {
+        setCategoryId(articleData.categories[0].id);
+
+        setDoNotInitiateRelatedArticlesQuery(false);
+      }
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [articleData]);
+
+  return (
+    <>
+      {articleData ? <ArticleDetail articleData={articleData} /> : null}
+
+      {relatedArticlesByCategoryData?.items &&
+        relatedArticlesByCategoryData.items.length > 0 && (
+          <RelatedSidebar
+            relatedArticlesByCategoryData={relatedArticlesByCategoryData.items}
+          />
+        )}
+    </>
+  );
 };
 
 export default ArticleDetailView;

--- a/web/src/features/article/pages/ArticleDetailView.tsx
+++ b/web/src/features/article/pages/ArticleDetailView.tsx
@@ -1,7 +1,36 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { useGetArticleByIdQuery } from 'common/api/articleExtendedApi';
 
 import { ArticleDetail } from 'features/article/components';
 
-const ArticleDetailView: FC = () => <ArticleDetail />;
+type TArticleParams = {
+  articleId: string;
+};
+
+const ArticleDetailView: FC = () => {
+  const [doNotInitiateQuery, setDoNotInitiateQuery] = useState<boolean>(true);
+  const { articleId } = useParams<TArticleParams>();
+
+  const { data: articleData } = useGetArticleByIdQuery(
+    articleId ? parseInt(articleId, 10) : 0,
+    {
+      skip: doNotInitiateQuery,
+    }
+  );
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (articleId) {
+        setDoNotInitiateQuery(false);
+      }
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [articleId]);
+
+  return articleData ? <ArticleDetail articleData={articleData} /> : null;
+};
 
 export default ArticleDetailView;

--- a/web/src/features/article/pages/ArticleDetailView.tsx
+++ b/web/src/features/article/pages/ArticleDetailView.tsx
@@ -29,9 +29,23 @@ const ArticleDetailView: FC = () => {
       skip: doNotInitiateArticleQuery,
     }
   );
-  const { data: relatedArticlesByCategoryData } =
+  const { dataWithoutCurrentArticle: relatedArticlesByCategoryData } =
     useGetArticlesByRelatedCategoryQuery(categoryId, {
       skip: doNotInitiateRelatedArticlesQuery,
+      // selectFromResult is used to return related articles without the current
+      // article in the current page view.
+      selectFromResult: (result) => ({
+        // Return original result from RTK for any debugging or needing it.
+        ...result,
+        // Create new property that returns the related articles without the
+        // current one in the page view.
+        dataWithoutCurrentArticle: result.data
+          ? result.data.items.filter(
+              // articleId is a string from URL params.
+              (relatedArticle) => `${relatedArticle.id}` !== articleId
+            )
+          : [],
+      }),
     });
 
   useEffect(() => {
@@ -60,12 +74,11 @@ const ArticleDetailView: FC = () => {
     <>
       {articleData ? <ArticleDetail articleData={articleData} /> : null}
 
-      {relatedArticlesByCategoryData?.items &&
-        relatedArticlesByCategoryData.items.length > 0 && (
-          <RelatedSidebar
-            relatedArticlesByCategoryData={relatedArticlesByCategoryData.items}
-          />
-        )}
+      {relatedArticlesByCategoryData.length > 0 && (
+        <RelatedSidebar
+          relatedArticlesByCategoryData={relatedArticlesByCategoryData}
+        />
+      )}
     </>
   );
 };


### PR DESCRIPTION
## Changes
1. Created another API RTK endpoint for `articleExtendedApi.ts` to get all articles based on related category.
2. Created a related sidebar and rendered it in the article detail page which displays any related articles based on a category while removing any articles that is the same as the current view page.

## Purpose
There should be a sidebar in the article detail page that displays any related articles that the user could click on.

Closes #87 