### PR TITLE
Fixed the Query Params for Tags Filtering in RTK (Web)

### DIFF
--- a/web/src/common/api/articleExtendedApi.ts
+++ b/web/src/common/api/articleExtendedApi.ts
@@ -50,7 +50,7 @@ const articleExtendedApi = coreSplitApi.injectEndpoints({
         }
 
         if (tags.length) {
-          tagsFiltering += `&tags=${tags.join(',')}`;
+          tagsFiltering += `&tags__in=${tags.join(',')}`;
         } else {
           tagsFiltering = '';
         }


### PR DESCRIPTION
## Changes
1. Changed the filter query path to match the Backend.

## Purpose
Since the tags query filtering in the Backend has been changed to target `?tags__in=`, the Frontend for its tags query filtering should reflect this change as well for `getArticles` in `articleExtendedApi.ts`.

Closes #93 