### PR TITLE
Fixed Categories RTK API Endpoint (Web)

### DIFF
--- a/web/src/common/api/categoryExtendedApi.ts
+++ b/web/src/common/api/categoryExtendedApi.ts
@@ -11,12 +11,14 @@ type TGetCategoriesResponse = IPaginationResponse & {
 const categoryExtendedApi = coreSplitApi.injectEndpoints({
   endpoints: (builder) => ({
     getCategories: builder.query<TGetCategoriesResponse, void>({
-      query: () => ({ url: `/categories/?fields=${fieldsParams}` }),
+      query: () => ({ url: `/article-categories/?fields=${fieldsParams}` }),
       providesTags: ['Category'],
     }),
 
     getCategoryById: builder.query<ICategory, number>({
-      query: (id) => ({ url: `/categories/${id}/?fields=${fieldsParams}` }),
+      query: (id) => ({
+        url: `/article-categories/${id}/?fields=${fieldsParams}`,
+      }),
       providesTags: ['Category'],
     }),
   }),


### PR DESCRIPTION
## Changes
1. Changed the path of the `category` API endpoint since it has been changed at the Backend.

## Purpose
Since the endpoint for all categories for article has been changed from `/api/v1/categories` to `/api/v1/article-categories`, the Frontend needs to reflect this change.

Closes #106 