### PR TITLE
Order by `first_released_at` in Descending for Work RTK API (Web)

### DIFF
--- a/web/src/common/api/workExtendedApi.ts
+++ b/web/src/common/api/workExtendedApi.ts
@@ -38,7 +38,7 @@ const workExtendedApi = coreSplitApi.injectEndpoints({
         if (category === 'Personal') categoryId = 2;
 
         return {
-          url: `/pages/?type=work.WorkPage&fields=_,id,uuid,title,slug,description,main_image,category,first_published_at,first_released_at&category=${categoryId}&limit=${limit}`,
+          url: `/pages/?type=work.WorkPage&fields=_,id,uuid,title,slug,description,main_image,category,first_published_at,first_released_at&category=${categoryId}&limit=${limit}&order=-first_released_at`,
         };
       },
 


### PR DESCRIPTION
## Changes
1. Changed the ordering in descending order.

## Purpose
The output for getting all the `work` RTK API should be ordered by `first_released_at` in descending order.

Closes #108 