### PR TITLE
Refactored Work Section in Landing Page to use the `workExtendedApi` (Web)

### DIFF
--- a/web/src/features/landing/components/WorkSection/index.tsx
+++ b/web/src/features/landing/components/WorkSection/index.tsx
@@ -49,7 +49,7 @@ const WorkSection: FC<IWorkSection> = ({ worksData }) => {
 
       <Container>
         {worksData.length > 0 &&
-          worksData.map((workData, workIndex) => (
+          worksData.slice(0, 3).map((workData, workIndex) => (
             <React.Fragment key={workData.uuid}>
               <LineSeparator rotateClass="negative-rotate" />
 

--- a/web/src/features/landing/components/WorkSection/index.tsx
+++ b/web/src/features/landing/components/WorkSection/index.tsx
@@ -1,14 +1,14 @@
 import React, { FC } from 'react';
 
-import kovviImage from 'assets/img/kovvi.png';
-import pokedexAppImage from 'assets/img/pokedex-app.png';
-import toadTribuneImage from 'assets/img/toad-tribune.png';
+import noImage from 'assets/img/no-image.png';
 
 import LineSeparator from 'common/components/LineSeparator';
 
 import { useIsHovering } from 'common/hooks';
 
 import HeadingSecondary from 'common/typography/HeadingSecondary';
+
+import { IWork } from 'common/models';
 
 import {
   Container,
@@ -17,40 +17,26 @@ import {
   Section,
   SectionTitle,
 } from './styles';
-import WorkContainer, { IWorkContainer } from './WorkContainer';
+import WorkContainer from './WorkContainer';
 
-const workContainerData: Omit<IWorkContainer, 'isExploreLinkHovering'>[] = [
-  {
-    workDescription:
-      'A cross-platform mobile app built with React Native that allows users to search COVID-19 data in a region, and view vaccine trial data.',
-    workImageAlt: 'Kovvi',
-    workImageSrc: kovviImage,
-    workLinkContent: 'View',
-    workLinkPath: '/',
-    workTitle: 'Kovvie',
-  },
-  {
-    reverseClass: 'reverse',
-    workDescription:
-      'A web app built with React and Node.js to provide top headline news from around the world: Politics, sports, stonks, movies, animals and your local weather.',
-    workImageAlt: 'The Toad Tribune',
-    workImageSrc: toadTribuneImage,
-    workLinkContent: 'View',
-    workLinkPath: '/',
-    workTitle: 'The Toad Tribune',
-  },
-  {
-    workDescription:
-      'A web app built with React that checks the type matchups of your Pokémon vs. any other Pokémon. With over 900 Pokémon in the Pokémon API database, the combinations are almost endless.',
-    workImageAlt: 'The Pokédex App',
-    workImageSrc: pokedexAppImage,
-    workLinkContent: 'View',
-    workLinkPath: '/',
-    workTitle: 'The Pokédex App',
-  },
-];
+type TWorksData = Pick<
+  IWork,
+  | 'category'
+  | 'description'
+  | 'first_released_at'
+  | 'id'
+  | 'main_image'
+  | 'title'
+  | 'uuid'
+> & {
+  meta: Pick<IWork['meta'], 'first_published_at' | 'slug'>;
+};
 
-const WorkSection: FC = () => {
+interface IWorkSection {
+  worksData: TWorksData[];
+}
+
+const WorkSection: FC<IWorkSection> = ({ worksData }) => {
   const [isHovering, setIsHovering] = useIsHovering();
 
   return (
@@ -62,24 +48,29 @@ const WorkSection: FC = () => {
       </SectionTitle>
 
       <Container>
-        {workContainerData.map((workData) => (
-          <React.Fragment
-            key={workData.workTitle.toLowerCase().split(' ').join('-')}
-          >
-            <LineSeparator rotateClass="negative-rotate" />
+        {worksData.length > 0 &&
+          worksData.map((workData, workIndex) => (
+            <React.Fragment key={workData.uuid}>
+              <LineSeparator rotateClass="negative-rotate" />
 
-            <WorkContainer
-              isExploreLinkHovering={isHovering}
-              reverseClass={workData.reverseClass}
-              workDescription={workData.workDescription}
-              workImageAlt={workData.workImageAlt}
-              workImageSrc={workData.workImageSrc}
-              workLinkContent={workData.workLinkContent}
-              workLinkPath={workData.workLinkPath}
-              workTitle={workData.workTitle}
-            />
-          </React.Fragment>
-        ))}
+              <WorkContainer
+                isExploreLinkHovering={isHovering}
+                workDescription={workData.description}
+                workImageAlt={workData.title}
+                workImageSrc={
+                  workData.main_image
+                    ? `http://localhost:8000${workData.main_image}`
+                    : noImage
+                }
+                workLinkContent="View"
+                workLinkPath={`/work/${workData.id}`}
+                workTitle={workData.title}
+                {...(workIndex % 2 !== 0 && {
+                  reverseClass: 'reverse',
+                })}
+              />
+            </React.Fragment>
+          ))}
       </Container>
 
       <ExploreMoreWrapper>

--- a/web/src/features/landing/pages/index.tsx
+++ b/web/src/features/landing/pages/index.tsx
@@ -1,5 +1,7 @@
 import React, { FC } from 'react';
 
+import { useGetWorksByCategoryQuery } from 'common/api/workExtendedApi';
+
 import SEO from 'common/components/SEO';
 
 import {
@@ -9,92 +11,108 @@ import {
   WorkSection,
 } from 'features/landing/components';
 
-const LandingListView: FC = () => (
-  <>
-    <SEO
-      openGraphMetaTags={[
-        {
-          property: 'og:description',
-          content:
-            'Software Engineer and Full-Stack Web Developer. Architecturing the art and mathemical model to create beautiful user experiences.',
-        },
-        {
-          property: 'og:image',
-          content: `${window.location.origin}/website-preview.png`,
-        },
-        {
-          property: 'og:site_name',
-          content: "Elias Gutierrez's Portfolio",
-        },
-        {
-          property: 'og:title',
-          content:
-            'Elias Gutierrez, Software Engineer & Full-Stack Web Developer',
-        },
-        {
-          property: 'og:type',
-          content: 'website',
-        },
-        {
-          property: 'og:url',
-          content: window.location.href,
-        },
-      ]}
-      primaryMetaTags={[
-        {
-          name: 'description',
-          content:
-            'Software Engineer and Full-Stack Web Developer. Architecturing the art and mathemical model to create beautiful user experiences.',
-        },
-        {
-          name: 'title',
-          content:
-            'Elias Gutierrez, Software Engineer & Full-Stack Web Developer',
-        },
-      ]}
-      title="Elias Gutierrez, Software Engineer & Full-Stack Web Developer"
-      twitterMetaTags={[
-        {
-          property: 'twitter:card',
-          content: 'summary',
-        },
-        {
-          property: 'twitter:creator',
-          content: '@_BlackCubes_',
-        },
-        {
-          property: 'twitter:description',
-          content:
-            'Software Engineer and Full-Stack Web Developer. Architecturing the art and mathemical model to create beautiful user experiences.',
-        },
-        {
-          property: 'twitter:image',
-          content: `${window.location.origin}/website-preview.png`,
-        },
-        {
-          property: 'twitter:site',
-          content: '@_BlackCubes_',
-        },
-        {
-          property: 'twitter:title',
-          content:
-            'Elias Gutierrez, Software Engineer & Full-Stack Web Developer',
-        },
-        {
-          property: 'twitter:url',
-          content: window.location.href,
-        },
-      ]}
-    />
+const LandingListView: FC = () => {
+  const { selectedData: worksData } = useGetWorksByCategoryQuery(
+    { category: 'Work', limit: 4 },
+    {
+      selectFromResult: (result) => ({
+        ...result,
+        selectedData: result.data
+          ? result.data.items.filter(
+              (resultData) => resultData.title !== 'Node News API'
+            )
+          : [],
+      }),
+    }
+  );
 
-    <HeroBanner />
+  return (
+    <>
+      <SEO
+        openGraphMetaTags={[
+          {
+            property: 'og:description',
+            content:
+              'Software Engineer and Full-Stack Web Developer. Architecturing the art and mathemical model to create beautiful user experiences.',
+          },
+          {
+            property: 'og:image',
+            content: `${window.location.origin}/website-preview.png`,
+          },
+          {
+            property: 'og:site_name',
+            content: "Elias Gutierrez's Portfolio",
+          },
+          {
+            property: 'og:title',
+            content:
+              'Elias Gutierrez, Software Engineer & Full-Stack Web Developer',
+          },
+          {
+            property: 'og:type',
+            content: 'website',
+          },
+          {
+            property: 'og:url',
+            content: window.location.href,
+          },
+        ]}
+        primaryMetaTags={[
+          {
+            name: 'description',
+            content:
+              'Software Engineer and Full-Stack Web Developer. Architecturing the art and mathemical model to create beautiful user experiences.',
+          },
+          {
+            name: 'title',
+            content:
+              'Elias Gutierrez, Software Engineer & Full-Stack Web Developer',
+          },
+        ]}
+        title="Elias Gutierrez, Software Engineer & Full-Stack Web Developer"
+        twitterMetaTags={[
+          {
+            property: 'twitter:card',
+            content: 'summary',
+          },
+          {
+            property: 'twitter:creator',
+            content: '@_BlackCubes_',
+          },
+          {
+            property: 'twitter:description',
+            content:
+              'Software Engineer and Full-Stack Web Developer. Architecturing the art and mathemical model to create beautiful user experiences.',
+          },
+          {
+            property: 'twitter:image',
+            content: `${window.location.origin}/website-preview.png`,
+          },
+          {
+            property: 'twitter:site',
+            content: '@_BlackCubes_',
+          },
+          {
+            property: 'twitter:title',
+            content:
+              'Elias Gutierrez, Software Engineer & Full-Stack Web Developer',
+          },
+          {
+            property: 'twitter:url',
+            content: window.location.href,
+          },
+        ]}
+      />
 
-    <WorkSection />
+      <HeroBanner />
 
-    <ArticleSection />
+      <WorkSection worksData={worksData} />
 
-    <TalkSection />
-  </>
-);
+      <ArticleSection />
+
+      <TalkSection />
+    </>
+  );
+};
 
 export default LandingListView;

--- a/web/src/features/landing/pages/index.tsx
+++ b/web/src/features/landing/pages/index.tsx
@@ -13,7 +13,7 @@ import {
 
 const LandingListView: FC = () => {
   const { selectedData: worksData } = useGetWorksByCategoryQuery(
-    { category: 'Work', limit: 4 },
+    { category: 'Work', limit: 5 },
     {
       selectFromResult: (result) => ({
         ...result,


### PR DESCRIPTION
## Changes
1. Changed the old code for the `WorkSection` in the landing page to use the `workExtendedApi` and displaying only three.

## Purpose
Since `workExtendedApi` has been created, the `WorkSection` in the landing page needs to be refactored to utilize the RTK API instead of using the hardcoded code.

Closes #110 