### PR TITLE
Fix the Styles for `LineSeparator` (Web)

### DIFF
--- a/web/src/common/base/GlobalStyle.tsx
+++ b/web/src/common/base/GlobalStyle.tsx
@@ -41,7 +41,6 @@ const GlobalStyle = createGlobalStyle`
 
   html,
   body {
-    width: 100vw;
     min-height: 100vh;
   }
 

--- a/web/src/common/components/LineSeparator/index.tsx
+++ b/web/src/common/components/LineSeparator/index.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 
-import { Container, PrimarySolidLine, SecondaryDottedLine } from './styles';
+import { Container, PrimarySolidLine } from './styles';
 
 export interface ILineSeparator {
   rotateClass?: string;
@@ -8,11 +8,7 @@ export interface ILineSeparator {
 
 const LineSeparator: FC<ILineSeparator> = ({ rotateClass }) => (
   <Container className={rotateClass}>
-    <SecondaryDottedLine />
-
     <PrimarySolidLine className="default-container" />
-
-    <SecondaryDottedLine />
   </Container>
 );
 

--- a/web/src/common/components/LineSeparator/styles.ts
+++ b/web/src/common/components/LineSeparator/styles.ts
@@ -1,10 +1,7 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
-  /* display: flex; */
-  display: none;
-  width: 200%;
-  margin-left: -50%;
+  width: 100%;
 
   &.positive-rotate {
     transform: rotate(4deg);
@@ -26,10 +23,4 @@ export const PrimarySolidLine = styled.div`
     margin-left: 0 !important;
     margin-right: 0 !important;
   }
-`;
-
-export const SecondaryDottedLine = styled.div`
-  width: 50%;
-  border: ${(props) =>
-    `0.1rem dotted rgba(${props.theme.colors.secondary.rgb}, 0.3)`};
 `;

--- a/web/src/features/article/components/ArticleList/styles.ts
+++ b/web/src/features/article/components/ArticleList/styles.ts
@@ -8,10 +8,7 @@ export const Section = styled.section`
   }
 `;
 
-export const SectionTitle = styled.div`
-  border-left: ${(props) =>
-    `0.1rem dotted rgba(${props.theme.colors.primary.rgb}, 0.7)`};
-`;
+export const SectionTitle = styled.div``;
 
 export const Container = styled.div`
   display: flex;

--- a/web/src/features/article/components/RelatedSidebar/styles.ts
+++ b/web/src/features/article/components/RelatedSidebar/styles.ts
@@ -44,7 +44,7 @@ export const RelatedItem = styled.li`
   margin-bottom: 1.2rem;
   padding-top: 0.4rem;
   border-top: 0.1rem solid
-    ${(props) => `rgba(${props.theme.colors.secondary.rgb}, 0.9)`};
+    ${(props) => `rgba(${props.theme.colors.secondary.rgb}, 0.4)`};
   list-style: none;
 
   @media ${({ theme }) => theme.responsive.below1199} {

--- a/web/src/features/landing/components/ArticleSection/styles.ts
+++ b/web/src/features/landing/components/ArticleSection/styles.ts
@@ -4,10 +4,7 @@ import styled from 'styled-components';
 // ARTICLE SECTION
 export const Section = styled.section``;
 
-export const SectionTitle = styled.div`
-  border-left: ${({ theme }) =>
-    `0.1rem dotted rgba(${theme.colors.primary.rgb}, 0.7)`};
-`;
+export const SectionTitle = styled.div``;
 
 export const Container = styled.div`
   display: flex;

--- a/web/src/features/landing/components/TalkSection/styles.ts
+++ b/web/src/features/landing/components/TalkSection/styles.ts
@@ -69,6 +69,16 @@ export const TalkTitleLink = styled.a`
   padding-right: 7rem;
   text-decoration: none;
 
+  @media ${({ theme }) => theme.responsive.below1199} {
+    padding-left: 4rem;
+    padding-right: 4rem;
+  }
+
+  @media ${({ theme }) => theme.responsive.below899} {
+    padding-left: 7rem;
+    padding-right: 7rem;
+  }
+
   @media ${({ theme }) => theme.responsive.below599} {
     padding-left: 2rem;
     padding-right: 2rem;

--- a/web/src/features/landing/components/TalkSection/styles.ts
+++ b/web/src/features/landing/components/TalkSection/styles.ts
@@ -4,45 +4,7 @@ import styled from 'styled-components';
 export const Section = styled.section``;
 
 export const SectionTitle = styled.div`
-  position: relative;
   text-align: center;
-
-  &:before,
-  &:after {
-    content: '';
-    position: absolute;
-    width: 1rem;
-    height: 6rem;
-    border-left: ${({ theme }) =>
-      `0.2rem dotted rgba(${theme.colors.primary.rgb}, 0.7)`};
-    opacity: 0.4;
-
-    @media ${({ theme }) => theme.responsive.below899} {
-      width: 1rem;
-      height: 6rem;
-      border-left: ${({ theme }) =>
-        `0.2rem dotted rgba(${theme.colors.primary.rgb}, 0.7)`};
-      opacity: 0.7;
-    }
-  }
-
-  &:before {
-    bottom: -0.6rem;
-    left: 109.5rem;
-    transform: rotate(-45deg);
-
-    @media ${({ theme }) => theme.responsive.below1199} {
-      left: 72.5rem;
-    }
-
-    @media ${({ theme }) => theme.responsive.below899} {
-      left: 68.2rem;
-    }
-  }
-
-  &:after {
-    left: -0.2rem;
-  }
 `;
 
 export const Container = styled.div`

--- a/web/src/features/landing/components/WorkSection/styles.ts
+++ b/web/src/features/landing/components/WorkSection/styles.ts
@@ -6,8 +6,6 @@ export const Section = styled.section``;
 
 export const SectionTitle = styled.div`
   text-align: right;
-  border-right: ${({ theme }) =>
-    `0.1rem dotted rgba(${theme.colors.primary.rgb}, 0.7)`};
 `;
 
 export const Container = styled.div`

--- a/web/src/features/work/components/PersonalList/styles.ts
+++ b/web/src/features/work/components/PersonalList/styles.ts
@@ -6,8 +6,6 @@ export const Section = styled.section``;
 
 export const SectionTitle = styled.div`
   text-align: right;
-  border-right: ${({ theme }) =>
-    `0.1rem dotted rgba(${theme.colors.primary.rgb}, 0.7)`};
 `;
 
 export const Container = styled.div`

--- a/web/src/features/work/components/WorkList/styles.ts
+++ b/web/src/features/work/components/WorkList/styles.ts
@@ -6,8 +6,6 @@ export const Section = styled.section``;
 
 export const SectionTitle = styled.div`
   text-align: right;
-  border-right: ${({ theme }) =>
-    `0.1rem dotted rgba(${theme.colors.primary.rgb}, 0.7)`};
 `;
 
 export const Container = styled.div`


### PR DESCRIPTION
## Changes
1. Change the `LineSeparator` component to be better stylistic and responsive.

## Purpose
The `LineSeparator` component needs to be responsive for all viewports.

Closes #139 