### PR TITLE
Fixed the LaTeX for all Viewports (Web)

### DIFF
--- a/web/src/common/components/Body/styles.ts
+++ b/web/src/common/components/Body/styles.ts
@@ -365,15 +365,22 @@ export const CodePreTag = styled.pre`
 
 export const BodyEquation = styled.div`
   margin: 2.5rem auto;
-  transform: scale(1.35);
+  transform: scale(1.3);
+
+  & .MJX-TEX {
+    white-space: normal;
+  }
+
+  @media ${({ theme }) => theme.responsive.below1199} {
+    transform: scale(1.15);
+  }
 
   @media ${({ theme }) => theme.responsive.below599} {
-    transform: scale(1.2);
+    transform: scale(1.1);
   }
 
   @media ${({ theme }) => theme.responsive.below479} {
     margin: 2rem auto;
-    transform: scale(1.1);
   }
 
   @media ${({ theme }) => theme.responsive.below379} {


### PR DESCRIPTION
## Changes
1. Fixed the `BodyEquation` to be responsive for all viewports.

## Purpose
The LaTeX for the body does not fit within the page, but instead it overflows out of the page when it has a lot of equations on one line.

Closes #144 