### PR TITLE
Fixed the Code Block in Body for all Viewports (Web)

### DIFF
--- a/web/src/common/components/Body/index.tsx
+++ b/web/src/common/components/Body/index.tsx
@@ -121,7 +121,6 @@ const Body: FC<IBody> = ({ bodyType, bodyValue }) => {
         <SyntaxHighlighter
           language={bodyValue.language}
           PreTag={CodePreTag}
-          showLineNumbers
           style={materialLight}
           wrapLongLines
         >

--- a/web/src/common/components/Body/styles.ts
+++ b/web/src/common/components/Body/styles.ts
@@ -338,14 +338,22 @@ export const BodyCode = styled.div`
   margin-bottom: 2.5rem;
   overflow-x: auto;
 
-  @media ${({ theme }) => theme.responsive.below479} {
+  @media ${({ theme }) => theme.responsive.below899} {
     font-size: 1.2rem;
+  }
+
+  @media ${({ theme }) => theme.responsive.below599} {
+    font-size: 1.1rem;
+  }
+
+  @media ${({ theme }) => theme.responsive.below479} {
+    font-size: 1rem;
     margin-top: 2rem;
     margin-bottom: 2rem;
   }
 
   @media ${({ theme }) => theme.responsive.below379} {
-    font-size: 1.1rem;
+    font-size: 0.9rem;
     width: 106%;
     transform: translateX(-0.6rem);
   }


### PR DESCRIPTION
## Changes
1. Made the code block to be responsive for all viewport widths.

## Purpose
The code block in the body should be responsive and purtty for all viewports.

Closes #146 