### PR TITLE
Added Link to Second Talk (Web)

### DIFF
--- a/web/src/features/landing/components/TalkSection/TalkContainer.tsx
+++ b/web/src/features/landing/components/TalkSection/TalkContainer.tsx
@@ -50,6 +50,8 @@ const TalkContainer: FC<ITalkContainer> = ({
 
         <TalkTitleLink
           href={talkLinkPath}
+          target="_blank"
+          rel="noopener"
           onMouseEnter={() => setIsHovering(true)}
           onMouseLeave={() => setIsHovering(false)}
         >

--- a/web/src/features/landing/components/TalkSection/index.tsx
+++ b/web/src/features/landing/components/TalkSection/index.tsx
@@ -22,7 +22,8 @@ const talkContainerData: ITalkContainer[] = [
     reverseClass: 'reverse',
     talkImageAlt: 'Redux Toolkit Presentation',
     talkImageSrc: talkPresentation2,
-    talkLinkPath: '#',
+    talkLinkPath:
+      'https://us02web.zoom.us/rec/play/coJ_z0w_gxEy5gP6iFtG1FLEuzuWey7dumrFH2xZ3rQQwGCBdy91Exb3Jyu2odOXj39rp-WKgEmPad2J.9De7TgEACj6xPmx3?continueMode=true',
     talkTitle:
       '"Converting Legacy Redux To Redux Toolkit" Developer Connect Presentation @ Bitwise Industries',
   },


### PR DESCRIPTION
## Changes
1. Added second link.

## Purpose
The second talk presentation should have an actual link instead of a dummy link in the landing page.

Closes #154 