### PR TITLE
Added Slug on Getting an Article/Work (API/Web)

### DIFF
--- a/web/src/common/api/articleExtendedApi.ts
+++ b/web/src/common/api/articleExtendedApi.ts
@@ -62,9 +62,9 @@ const articleExtendedApi = coreSplitApi.injectEndpoints({
       providesTags: ['Article'],
     }),
 
-    getArticleById: builder.query<IArticle, number>({
-      query: (id) => ({
-        url: `/pages/${id}/?fields=_,id,uuid,title,slug,description,header_image,body,tags,category,seo_title,search_description,first_published_at,reading_time`,
+    getArticleBySlug: builder.query<IArticle, string>({
+      query: (slug) => ({
+        url: `/pages/${slug}/?fields=_,id,uuid,title,slug,description,header_image,body,tags,category,seo_title,search_description,first_published_at,reading_time`,
       }),
       providesTags: ['Article'],
     }),
@@ -84,7 +84,7 @@ const articleExtendedApi = coreSplitApi.injectEndpoints({
 });
 
 export const {
-  useGetArticleByIdQuery,
+  useGetArticleBySlugQuery,
   useGetArticlesByRelatedCategoryQuery,
   useGetArticlesQuery,
 } = articleExtendedApi;

--- a/web/src/common/api/workExtendedApi.ts
+++ b/web/src/common/api/workExtendedApi.ts
@@ -45,9 +45,9 @@ const workExtendedApi = coreSplitApi.injectEndpoints({
       providesTags: ['Work'],
     }),
 
-    getWorkById: builder.query<IWork, number>({
-      query: (id) => ({
-        url: `/pages/${id}/?fields=_,id,uuid,first_published_at,slug,seo_title,search_description,title,description,main_image,logo_image,company,first_released_at,category,body`,
+    getWorkBySlug: builder.query<IWork, string>({
+      query: (slug) => ({
+        url: `/pages/${slug}/?fields=_,id,uuid,first_published_at,slug,seo_title,search_description,title,description,main_image,logo_image,company,first_released_at,category,body`,
       }),
 
       providesTags: ['Work'],
@@ -57,5 +57,5 @@ const workExtendedApi = coreSplitApi.injectEndpoints({
   overrideExisting: false,
 });
 
-export const { useGetWorkByIdQuery, useGetWorksByCategoryQuery } =
+export const { useGetWorkBySlugQuery, useGetWorksByCategoryQuery } =
   workExtendedApi;

--- a/web/src/features/article/Routes.tsx
+++ b/web/src/features/article/Routes.tsx
@@ -5,7 +5,7 @@ import { ArticleDetailView, ArticleListView } from './pages';
 
 const ArticleRoutes: FC = () => (
   <Routes>
-    <Route path="/:articleId" element={<ArticleDetailView />} />
+    <Route path="/:articleSlug" element={<ArticleDetailView />} />
     <Route path="" element={<ArticleListView />} />
   </Routes>
 );

--- a/web/src/features/article/components/ArticleList/index.tsx
+++ b/web/src/features/article/components/ArticleList/index.tsx
@@ -55,7 +55,7 @@ const ArticleList: FC<IArticleList> = ({ articlesData }) => (
                 ? `http://localhost:8000${article.header_image}`
                 : noImage
             }
-            articleLinkPath={`/articles/${article.id}`}
+            articleLinkPath={`/articles/${article.meta.slug}`}
             articleReadingTime={article.reading_time}
             articleTags={article.tags}
             articleTitle={article.title}

--- a/web/src/features/article/components/RelatedSidebar/index.tsx
+++ b/web/src/features/article/components/RelatedSidebar/index.tsx
@@ -49,7 +49,7 @@ const RelatedSidebar: FC<IRelatedSidebar> = ({
           <SidebarList>
             {relatedArticlesByCategoryData.slice(0, 4).map((relatedArticle) => (
               <RelatedItem key={relatedArticle.uuid}>
-                <RelatedLink to={`/articles/${relatedArticle.id}`}>
+                <RelatedLink to={`/articles/${relatedArticle.meta.slug}`}>
                   <RelatedContainer>
                     <RelatedImageWrapper>
                       <GlassCircle

--- a/web/src/features/article/pages/ArticleDetailView.tsx
+++ b/web/src/features/article/pages/ArticleDetailView.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'react-router-dom';
 import noImage from 'assets/img/no-image.png';
 
 import {
-  useGetArticleByIdQuery,
+  useGetArticleBySlugQuery,
   useGetArticlesByRelatedCategoryQuery,
 } from 'common/api/articleExtendedApi';
 
@@ -15,7 +15,7 @@ import { ArticleDetail, RelatedSidebar } from 'features/article/components';
 import { PageContainer } from './styles';
 
 type TArticleParams = {
-  articleId: string;
+  articleSlug: string;
 };
 
 const ArticleDetailView: FC = () => {
@@ -26,11 +26,11 @@ const ArticleDetailView: FC = () => {
     setDoNotInitiateRelatedArticlesQuery,
   ] = useState<boolean>(true);
 
-  const { articleId } = useParams<TArticleParams>();
+  const { articleSlug } = useParams<TArticleParams>();
   const [categoryId, setCategoryId] = useState<number>(0);
 
-  const { data: articleData } = useGetArticleByIdQuery(
-    articleId ? parseInt(articleId, 10) : 0,
+  const { data: articleData } = useGetArticleBySlugQuery(
+    articleSlug ?? 'does-not-exist',
     {
       skip: doNotInitiateArticleQuery,
     }
@@ -48,7 +48,7 @@ const ArticleDetailView: FC = () => {
         dataWithoutCurrentArticle: result.data
           ? result.data.items.filter(
               // articleId is a string from URL params.
-              (relatedArticle) => `${relatedArticle.id}` !== articleId
+              (relatedArticle) => relatedArticle.meta.slug !== articleSlug
             )
           : [],
       }),
@@ -56,13 +56,13 @@ const ArticleDetailView: FC = () => {
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      if (articleId) {
+      if (articleSlug) {
         setDoNotInitiateArticleQuery(false);
       }
     }, 1000);
 
     return () => clearTimeout(timer);
-  }, [articleId]);
+  }, [articleSlug]);
 
   useEffect(() => {
     const timer = setTimeout(() => {

--- a/web/src/features/landing/components/WorkSection/index.tsx
+++ b/web/src/features/landing/components/WorkSection/index.tsx
@@ -63,7 +63,7 @@ const WorkSection: FC<IWorkSection> = ({ worksData }) => {
                     : noImage
                 }
                 workLinkContent="View"
-                workLinkPath={`/work/${workData.id}`}
+                workLinkPath={`/work/${workData.meta.slug}`}
                 workTitle={workData.title}
                 {...(workIndex % 2 !== 0 && {
                   reverseClass: 'reverse',

--- a/web/src/features/work/Routes.tsx
+++ b/web/src/features/work/Routes.tsx
@@ -5,7 +5,7 @@ import { WorkDetailView, WorkListView } from './pages';
 
 const WorkRoutes: FC = () => (
   <Routes>
-    <Route path="/:workId" element={<WorkDetailView />} />
+    <Route path="/:workSlug" element={<WorkDetailView />} />
     <Route path="" element={<WorkListView />} />
   </Routes>
 );

--- a/web/src/features/work/components/PersonalList/index.tsx
+++ b/web/src/features/work/components/PersonalList/index.tsx
@@ -49,7 +49,7 @@ const PersonalList: FC<IPersonalList> = ({ personalsData }) => (
               ? `http://localhost:8000${personalData.logo_image}`
               : noImage
           }
-          personalPath={`/work/${personalData.id}`}
+          personalPath={`/work/${personalData.meta.slug}`}
           personalTitle={personalData.title}
           {...(personalIndex % 2 !== 0 && {
             reverseClass: 'reverse',

--- a/web/src/features/work/components/WorkList/index.tsx
+++ b/web/src/features/work/components/WorkList/index.tsx
@@ -49,7 +49,7 @@ const WorkList: FC<IWorkList> = ({ worksData }) => (
               ? `http://localhost:8000${workData.logo_image}`
               : noImage
           }
-          workLinkPath={`/work/${workData.id}`}
+          workLinkPath={`/work/${workData.meta.slug}`}
           workTitle={workData.title}
           {...(workIndex % 2 === 0 && {
             reverseClass: 'reverse',

--- a/web/src/features/work/pages/WorkDetailView.tsx
+++ b/web/src/features/work/pages/WorkDetailView.tsx
@@ -3,24 +3,24 @@ import { useParams } from 'react-router-dom';
 
 import noImage from 'assets/img/no-image.png';
 
-import { useGetWorkByIdQuery } from 'common/api/workExtendedApi';
+import { useGetWorkBySlugQuery } from 'common/api/workExtendedApi';
 
 import SEO from 'common/components/SEO';
 
 import { WorkDetail } from 'features/work/components';
 
 type TWorkParams = {
-  workId: string;
+  workSlug: string;
 };
 
 const WorkDetailView: FC = () => {
   const [doNotInitiateWorkQuery, setDoNotInitiateWorkQuery] =
     useState<boolean>(true);
 
-  const { workId } = useParams<TWorkParams>();
+  const { workSlug } = useParams<TWorkParams>();
 
-  const { data: workData } = useGetWorkByIdQuery(
-    workId ? parseInt(workId, 10) : 0,
+  const { data: workData } = useGetWorkBySlugQuery(
+    workSlug ?? 'does-not-exist',
     {
       skip: doNotInitiateWorkQuery,
     }
@@ -28,13 +28,13 @@ const WorkDetailView: FC = () => {
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      if (workId) {
+      if (workSlug) {
         setDoNotInitiateWorkQuery(false);
       }
     }, 1000);
 
     return () => clearTimeout(timer);
-  }, [workId]);
+  }, [workSlug]);
 
   if (!workData) {
     return null;


### PR DESCRIPTION
## Changes
1. API: Added URL parameter support for accepting both the primary key and slug.
2. WEB: Changed and refactored some of the code to target the slug and not the primary key so that the URL looks pretty.

## Purpose
When getting one article/work, Wagtail only accepts the model's ID but not a slug. This should be changed where it accepts both a slug and an ID. Once this is achieved, the Frontend should be changed on getting an article/work based on its slug from the Backend.

All of this is being done so that the URL looks better 😅.

Closes #156 