### PR TITLE
Changed Article Links to the Actual Page in Landing Page (Web)

### DIFF
--- a/web/src/common/api/articleExtendedApi.ts
+++ b/web/src/common/api/articleExtendedApi.ts
@@ -18,6 +18,7 @@ type TGetArticles = Pick<
 
 type TGetArticlesRequest = {
   category: number;
+  limit?: number;
   tags: Array<number> | [];
 };
 
@@ -39,14 +40,21 @@ type TGetArticlesByRelatedCategoryResponse = IPaginationResponse & {
 const articleExtendedApi = coreSplitApi.injectEndpoints({
   endpoints: (builder) => ({
     getArticles: builder.query<TGetArticlesResponse, TGetArticlesRequest>({
-      query: ({ category, tags }) => {
+      query: ({ category, limit, tags }) => {
         let categoryFiltering: string = '';
+        let limitFiltering: string = '';
         let tagsFiltering: string = '';
 
         if (category > 0) {
           categoryFiltering += `&category=${category}`;
         } else {
           categoryFiltering = '';
+        }
+
+        if (limit) {
+          limitFiltering = `&limit=${limit}`;
+        } else {
+          limitFiltering = '';
         }
 
         if (tags.length) {
@@ -56,7 +64,7 @@ const articleExtendedApi = coreSplitApi.injectEndpoints({
         }
 
         return {
-          url: `/pages/?type=article.ArticlePage&fields=_,id,uuid,title,slug,description,header_image,tags,category,first_published_at,reading_time${categoryFiltering}${tagsFiltering}`,
+          url: `/pages/?type=article.ArticlePage&fields=_,id,uuid,title,slug,description,header_image,tags,category,first_published_at,reading_time${categoryFiltering}${tagsFiltering}${limitFiltering}`,
         };
       },
       providesTags: ['Article'],

--- a/web/src/features/landing/components/ArticleSection/index.tsx
+++ b/web/src/features/landing/components/ArticleSection/index.tsx
@@ -1,12 +1,12 @@
 import React, { FC } from 'react';
 
-import dummyArticle1 from 'assets/img/dummy-article1.png';
-import dummyArticle2 from 'assets/img/dummy-article2.png';
-import dummyArticle3 from 'assets/img/dummy-article3.jpg';
+import noImage from 'assets/img/no-image.png';
 
 import LineSeparator from 'common/components/LineSeparator';
 
 import { useIsHovering } from 'common/hooks';
+
+import { IArticle } from 'common/models';
 
 import HeadingSecondary from 'common/typography/HeadingSecondary';
 import Paragraph from 'common/typography/Paragraph';
@@ -20,34 +20,27 @@ import {
   SectionTitle,
   Wrapper,
 } from './styles';
-import ArticleContainer, { IArticleContainer } from './ArticleContainer';
+import ArticleContainer from './ArticleContainer';
 
-const articleContainerData: Omit<IArticleContainer, 'isExploreLinkHovering'>[] =
-  [
-    {
-      articleClass: 'article1',
-      articleImageAlt: 'Dummy Article 1',
-      articleImageSrc: dummyArticle1,
-      articleLinkPath: '/',
-      articleTitle: 'Article Title',
-    },
-    {
-      articleClass: 'article2',
-      articleImageAlt: 'Dummy Article 2',
-      articleImageSrc: dummyArticle2,
-      articleLinkPath: '/',
-      articleTitle: 'Article Title',
-    },
-    {
-      articleClass: 'article3',
-      articleImageAlt: 'Dummy Article 3',
-      articleImageSrc: dummyArticle3,
-      articleLinkPath: '/',
-      articleTitle: 'Article Title',
-    },
-  ];
+type TArticlesData = Pick<
+  IArticle,
+  | 'description'
+  | 'header_image'
+  | 'id'
+  | 'title'
+  | 'uuid'
+  | 'reading_time'
+  | 'category'
+  | 'tags'
+> & {
+  meta: Pick<IArticle['meta'], 'slug' | 'first_published_at'>;
+};
 
-const ArticleSection: FC = () => {
+interface IArticleSection {
+  articlesData: TArticlesData[] | [];
+}
+
+const ArticleSection: FC<IArticleSection> = ({ articlesData }) => {
   const [isHovering, setIsHovering] = useIsHovering();
 
   return (
@@ -70,20 +63,23 @@ const ArticleSection: FC = () => {
         </Introduction>
 
         <Wrapper>
-          {articleContainerData.map((articleData) => (
-            <React.Fragment
-              key={articleData.articleTitle.toLowerCase().split(' ').join('-')}
-            >
-              <ArticleContainer
-                isExploreLinkHovering={isHovering}
-                articleClass={articleData.articleClass}
-                articleImageAlt={articleData.articleImageAlt}
-                articleImageSrc={articleData.articleImageSrc}
-                articleLinkPath={articleData.articleLinkPath}
-                articleTitle={articleData.articleTitle}
-              />
-            </React.Fragment>
-          ))}
+          {articlesData.length > 0 &&
+            articlesData.map((articleData, articleIndex) => (
+              <React.Fragment key={articleData.uuid}>
+                <ArticleContainer
+                  isExploreLinkHovering={isHovering}
+                  articleClass={`article${articleIndex + 1}`}
+                  articleImageAlt={articleData.title}
+                  articleImageSrc={
+                    articleData.header_image
+                      ? `http://localhost:8000${articleData.header_image}`
+                      : noImage
+                  }
+                  articleLinkPath={`/article/${articleData.meta.slug}`}
+                  articleTitle={articleData.title}
+                />
+              </React.Fragment>
+            ))}
         </Wrapper>
       </Container>
 

--- a/web/src/features/landing/components/ArticleSection/styles.ts
+++ b/web/src/features/landing/components/ArticleSection/styles.ts
@@ -225,5 +225,18 @@ export const ArticleImageWrapper = styled.div`
 `;
 
 export const ArticleTitleLink = styled(Link)`
+  text-align: center;
   text-decoration: none;
+
+  & h3 {
+    max-width: 30.1rem;
+    max-height: 3.4rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-wrap: break-word;
+
+    @media ${({ theme }) => theme.responsive.below899} {
+      max-height: 2.5rem;
+    }
+  }
 `;

--- a/web/src/features/landing/pages/index.tsx
+++ b/web/src/features/landing/pages/index.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import { useGetArticlesQuery } from 'common/api/articleExtendedApi';
 import { useGetWorksByCategoryQuery } from 'common/api/workExtendedApi';
 
 import SEO from 'common/components/SEO';
@@ -12,6 +13,12 @@ import {
 } from 'features/landing/components';
 
 const LandingListView: FC = () => {
+  const { data: articlesData } = useGetArticlesQuery({
+    category: 0,
+    limit: 3,
+    tags: [],
+  });
+
   const { selectedData: worksData } = useGetWorksByCategoryQuery(
     { category: 'Work', limit: 5 },
     {
@@ -108,7 +115,7 @@ const LandingListView: FC = () => {
 
       <WorkSection worksData={worksData} />
 
-      <ArticleSection />
+      <ArticleSection articlesData={articlesData?.items ?? []} />
 
       <TalkSection />
     </>


### PR DESCRIPTION
## Changes
1. Removed the old code to not use the dummy articles data, but an actual one.

## Purpose
The article links in the landing page should have actual links pointing (and not dummy links) to the detail page.

Closes #158 