### PR TITLE
Fixed Footer Icon Links to Open New Tab (Wab)

### DIFF
--- a/web/src/common/components/Footer/index.tsx
+++ b/web/src/common/components/Footer/index.tsx
@@ -55,7 +55,11 @@ const Footer: FC = () => {
 
         <LogosContainer>
           <LogoWrapper>
-            <LogoLink href="https://github.com/BlackCubes">
+            <LogoLink
+              href="https://github.com/BlackCubes"
+              rel="noopener"
+              target="_blank"
+            >
               <Logo
                 src={githubLogo}
                 alt="Github Logo"
@@ -65,7 +69,11 @@ const Footer: FC = () => {
           </LogoWrapper>
 
           <LogoWrapper>
-            <LogoLink href="https://twitter.com/_BlackCubes_">
+            <LogoLink
+              href="https://twitter.com/_BlackCubes_"
+              rel="noopener"
+              target="_blank"
+            >
               <Logo
                 src={twitterLogo}
                 alt="Twitter Logo"
@@ -75,7 +83,11 @@ const Footer: FC = () => {
           </LogoWrapper>
 
           <LogoWrapper>
-            <LogoLink href="https://www.linkedin.com/in/eliasgutierrez1991/">
+            <LogoLink
+              href="https://www.linkedin.com/in/eliasgutierrez1991/"
+              rel="noopener"
+              target="_blank"
+            >
               <Logo
                 src={linkedinLogo}
                 alt="LinkedIn Logo"


### PR DESCRIPTION
## Changes
1. Made the footer icon links open to a new tab in the user's browser.

## Purpose
When the user clicks on the icon links from the footer, it should open on a new tab. Instead, it goes to that link on the current page which could lead the user to be annoyed that they have to go back to the portfolio site.

Closes #181 