### PR TITLE
Fixed the Highlight for the Navbar and Footer in the Detail Pages (Web)

### DIFF
--- a/web/src/common/components/ItemLink/ItemLink.tsx
+++ b/web/src/common/components/ItemLink/ItemLink.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { useMatch, useResolvedPath } from 'react-router-dom';
+import { useLocation, useMatch, useResolvedPath } from 'react-router-dom';
 
 import { ItemLinkStyle } from './styles';
 
@@ -9,13 +9,22 @@ export interface IItemLink {
   to: string;
 }
 
+/* eslint-disable no-nested-ternary */
 const ItemLink: FC<IItemLink> = ({ onClick, itemTitle, to }) => {
   const resolved = useResolvedPath(to);
   const match = useMatch({ path: resolved.pathname, end: true });
 
+  const location = useLocation();
+
   return (
     <ItemLinkStyle
-      className={match ? 'active' : ''}
+      className={
+        match
+          ? 'active'
+          : location.pathname.includes(itemTitle.toLowerCase())
+          ? 'active'
+          : ''
+      }
       to={to}
       {...(onClick && {
         onClick,


### PR DESCRIPTION
## Changes
1. Fixed the highlight for the links in the Navbar and Footer by checking if the item title matches the location pathname.

## Purpose
When going to the detail page for the article or work, there should be a highlight for the "Work" and "Articles" tabs in both the Navbar and Footer. Instead, there is none and needs to be fixed.

Closes #183 