### PR TITLE
Fixed the Scroll to the Top of the Page Between Page Transitions (Web)

### DIFF
--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -54,7 +54,10 @@ const App = () => {
 
       <DarkModeToggle />
 
-      <AnimatePresence exitBeforeEnter>
+      <AnimatePresence
+        exitBeforeEnter
+        onExitComplete={() => window.scroll(0, 0)}
+      >
         <Routes location={location} key={location.pathname}>
           <Route
             path=""


### PR DESCRIPTION
## Changes
1. Fixed the scroll to go to the top of the page when there is a page transition.

## Purpose
When the user goes to the next page, it should scroll the user to the top of the page to have a smoother and better user experience. Instead, it currently does not do that where it would stay at the current position between page transitions.

Closes #185 