### PR TITLE
Fixed `ALLOWED_HOSTS` For Production (API)

### DIFF
--- a/api/core/settings/production.py
+++ b/api/core/settings/production.py
@@ -19,8 +19,8 @@ DEBUG = False
 SECRET_KEY = os.getenv("SECRET_KEY")
 
 ALLOWED_HOSTS = (
-    "BlackCubes.pythonanywhere",
-    "www.BlackCubes.pythonanywhere",
+    "blackcubes.pythonanywhere.com",
+    "www.blackcubes.pythonanywhere.com",
 )
 
 CORS_ALLOWED_ORIGINS = [


### PR DESCRIPTION
## Purpose
On deployment to a host, the server should respond successfully given the current LIVE remote URL, but instead it is throwing a `BAD REQUEST` error by the host provider. This is due to incorrect paths from `ALLOWED_HOSTS` in `api/core/settings/production.py`. Originally, they were this:

```
ALLOWED_HOSTS = (
    "BlackCubes.pythonanywhere",
    "www.BlackCubes.pythonanywhere",
)
```

They were changed to this:

```
ALLOWED_HOSTS = (
    "blackcubes.pythonanywhere.com",
    "www.blackcubes.pythonanywhere.com",
)
```

Closes #211 