### PR TITLE
Fixed the API Image Previews During Production (Web)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -37,6 +37,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "predeploy:staging": "cross-env REACT_APP_CONFIGURATION=staging react-scripts build",
+    "predeploy:production": "cross-env REACT_APP_CONFIGURATION=production react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/web/src/common/components/Body/index.tsx
+++ b/web/src/common/components/Body/index.tsx
@@ -103,7 +103,13 @@ const Body: FC<IBody> = ({ bodyType, bodyValue }) => {
             glassLightShadowVerticalOffset={-0.1}
             imageAlt={bodyValue.caption}
             imageSrc={
-              bodyValue.image ? environment.apiRoute + bodyValue.image : noImage
+              bodyValue.image
+                ? `${
+                    environment.isProduction
+                      ? bodyValue.image
+                      : environment.apiRoute + bodyValue.image
+                  }`
+                : noImage
             }
             opacity={1}
           />

--- a/web/src/features/article/components/ArticleDetail/index.tsx
+++ b/web/src/features/article/components/ArticleDetail/index.tsx
@@ -268,7 +268,11 @@ const ArticleDetail: FC<IArticleDetail> = ({ articleData }) => {
           imageAlt="Header image for article"
           imageSrc={
             articleData.header_image
-              ? environment.apiRoute + articleData.header_image
+              ? `${
+                  environment.isProduction
+                    ? articleData.header_image
+                    : environment.apiRoute + articleData.header_image
+                }`
               : noImage
           }
           opacity={1}

--- a/web/src/features/article/components/ArticleList/index.tsx
+++ b/web/src/features/article/components/ArticleList/index.tsx
@@ -71,7 +71,11 @@ const ArticleList: FC<IArticleList> = ({ articlesData }) => {
               articleImageAlt={article.title}
               articleImageSrc={
                 article.header_image
-                  ? environment.apiRoute + article.header_image
+                  ? `${
+                      environment.isProduction
+                        ? article.header_image
+                        : environment.apiRoute + article.header_image
+                    }`
                   : noImage
               }
               articleLinkPath={`/articles/${article.meta.slug}`}

--- a/web/src/features/article/pages/ArticleDetailView.tsx
+++ b/web/src/features/article/pages/ArticleDetailView.tsx
@@ -117,7 +117,11 @@ const ArticleDetailView: FC = () => {
             {
               property: 'og:image',
               content: articleData.header_image
-                ? environment.apiRoute + articleData.header_image
+                ? `${
+                    environment.isProduction
+                      ? articleData.header_image
+                      : environment.apiRoute + articleData.header_image
+                  }`
                 : noImage,
             },
             {
@@ -188,7 +192,11 @@ const ArticleDetailView: FC = () => {
             {
               property: 'twitter:image',
               content: articleData.header_image
-                ? environment.apiRoute + articleData.header_image
+                ? `${
+                    environment.isProduction
+                      ? articleData.header_image
+                      : environment.apiRoute + articleData.header_image
+                  }`
                 : noImage,
             },
             {

--- a/web/src/features/landing/components/ArticleSection/index.tsx
+++ b/web/src/features/landing/components/ArticleSection/index.tsx
@@ -120,7 +120,11 @@ const ArticleSection: FC<IArticleSection> = ({
                   articleImageAlt={articleData.title}
                   articleImageSrc={
                     articleData.header_image
-                      ? environment.apiRoute + articleData.header_image
+                      ? `${
+                          environment.isProduction
+                            ? articleData.header_image
+                            : environment.apiRoute + articleData.header_image
+                        }`
                       : noImage
                   }
                   articleLinkPath={`/articles/${articleData.meta.slug}`}

--- a/web/src/features/landing/components/WorkSection/index.tsx
+++ b/web/src/features/landing/components/WorkSection/index.tsx
@@ -93,7 +93,11 @@ const WorkSection: FC<IWorkSection> = ({ finishIsFirstMount, worksData }) => {
                 workImageAlt={workData.title}
                 workImageSrc={
                   workData.logo_image
-                    ? environment.apiRoute + workData.logo_image
+                    ? `${
+                        environment.isProduction
+                          ? workData.logo_image
+                          : environment.apiRoute + workData.logo_image
+                      }`
                     : noImage
                 }
                 workLinkPath={`/work/${workData.meta.slug}`}

--- a/web/src/features/work/components/PersonalList/index.tsx
+++ b/web/src/features/work/components/PersonalList/index.tsx
@@ -65,7 +65,11 @@ const PersonalList: FC<IPersonalList> = ({ personalsData }) => {
             personalImageAlt={personalData.title}
             personalImageSrc={
               personalData.logo_image
-                ? environment.apiRoute + personalData.logo_image
+                ? `${
+                    environment.isProduction
+                      ? personalData.logo_image
+                      : environment.apiRoute + personalData.logo_image
+                  }`
                 : noImage
             }
             personalPath={`/work/${personalData.meta.slug}`}

--- a/web/src/features/work/components/WorkDetail/index.tsx
+++ b/web/src/features/work/components/WorkDetail/index.tsx
@@ -196,7 +196,11 @@ const WorkDetail: FC<IWorkDetail> = ({ workData }) => {
           imageAlt="Header image for article"
           imageSrc={
             workData.main_image
-              ? environment.apiRoute + workData.main_image
+              ? `${
+                  environment.isProduction
+                    ? workData.main_image
+                    : environment.apiRoute + workData.main_image
+                }`
               : noImage
           }
           opacity={1}

--- a/web/src/features/work/components/WorkList/index.tsx
+++ b/web/src/features/work/components/WorkList/index.tsx
@@ -65,7 +65,11 @@ const WorkList: FC<IWorkList> = ({ worksData }) => {
             workImageAlt={workData.title}
             workImageSrc={
               workData.logo_image
-                ? environment.apiRoute + workData.logo_image
+                ? `${
+                    environment.isProduction
+                      ? workData.logo_image
+                      : environment.apiRoute + workData.logo_image
+                  }`
                 : noImage
             }
             workLinkPath={`/work/${workData.meta.slug}`}

--- a/web/src/features/work/pages/WorkDetailView.tsx
+++ b/web/src/features/work/pages/WorkDetailView.tsx
@@ -60,7 +60,11 @@ const WorkDetailView: FC = () => {
             {
               property: 'og:image',
               content: workData.main_image
-                ? environment.apiRoute + workData.main_image
+                ? `${
+                    environment.isProduction
+                      ? workData.main_image
+                      : environment.apiRoute + workData.main_image
+                  }`
                 : noImage,
             },
             {
@@ -123,7 +127,11 @@ const WorkDetailView: FC = () => {
             {
               property: 'twitter:image',
               content: workData.main_image
-                ? environment.apiRoute + workData.main_image
+                ? `${
+                    environment.isProduction
+                      ? workData.main_image
+                      : environment.apiRoute + workData.main_image
+                  }`
                 : noImage,
             },
             {


### PR DESCRIPTION
## Purpose
During production, the images from AWS S3 should be displayed. Instead, it is using the old code to prefix the API website path with the image URL.

Closes #216 