### PR TITLE
fix(core-production): add extra URL for CORS

### DIFF
--- a/api/core/settings/production.py
+++ b/api/core/settings/production.py
@@ -25,6 +25,7 @@ ALLOWED_HOSTS = (
 
 CORS_ALLOWED_ORIGINS = [
     "https://eliastgutierrez.com",
+    "https://www.eliastgutierrez.com",
 ]
 
 CORS_ALLOW_METHODS = [


### PR DESCRIPTION
## Changes
1. Added an extra URL path for CORS.

## Purpose
On deployment to a host, the server should respond successfully given the current LIVE remote URL, but instead it is not throwing a `BAD REQUEST` error by the host provider. This is due to not having one more path for `CORS_ALLOWED_ORIGINS` in `api/core/settings/production.py`. Originally, it is this:

```
CORS_ALLOWED_ORIGINS = [
    "https://eliastgutierrez.com",
]
```

There needs to be one more:

```
CORS_ALLOWED_ORIGINS = [
    "https://eliastgutierrez.com",
    "https://www.eliastgutierrez.com",
]
```

Closes #223 