### PR TITLE
Changed Path from Package in `netlify.toml`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [[plugins]]
-  package = "@netlify/plugin-nextjs"
+  package = "/web/@netlify/plugin-nextjs"
 
 [[redirects]]
   from = "https://github.com/blackcubes"


### PR DESCRIPTION
## Changes
1. Changed path.

## Purpose
The site fails to deploy (or build) on Netlify since currently in `netlify.toml` the package path under `[[plugins]]` is not pointing to the right one. It should be pointing to the `web/` folder.

Closes #240 