### PR TITLE
Added Build Command to `netlify.toml`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,6 @@
+[build]
+  ignore = "false"
+
 [[redirects]]
   from = "https://github.com/blackcubes"
   to = "https://github.com/blackcubes"


### PR DESCRIPTION
## Changes
1. Added build command for Netlify to build once the `main` branch gets merged.

## Purpose
Once the `development` branch gets merged into the `main` branch, Netlify will start deploying. The issue is that it would not build the production site unless there is a setting in `netlify.toml` to not ignore it ([source](https://docs.netlify.com/configure-builds/ignore-builds/)).

Closes #258 