### PR TITLE
Fixed `netlify.toml`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -90,8 +90,3 @@
   to = "https://aws.amazon.com/s3/"
   status = 200
   force = true
-
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200


### PR DESCRIPTION
## Changes
1. Removed the old settings that was used for `v2`.

## Purpose
The `[[redirects]]` in `netlify.toml` still has a setting for `"index.html"` from the `v2` that used the normal React.js without Next.js. This might cause conflicts with the Next.js plugin, and it needs to be removed.

Closes #261 