### PR TITLE
Removed `"type"` from `package.json` (Web)

### DIFF
--- a/web/next-sitemap.config.js
+++ b/web/next-sitemap.config.js
@@ -1,18 +1,14 @@
-const siteUrl = 'https://www.eliastgutierrez.com';
-
 /** @type {import('next-sitemap').IConfig} */
-const config = {
-  siteUrl,
+module.exports = {
+  siteUrl: 'https://www.eliastgutierrez.com',
   generateRobotsTxt: true,
   generateIndexSitemap: false,
   exclude: ['/server-sitemap.xml'],
   robotsTxtOptions: {
     policies: [{ userAgent: '*', allow: '/' }],
     additionalSitemaps: [
-      `${siteUrl}/sitemap.xml`,
-      `${siteUrl}/server-sitemap.xml`,
+      'https://www.eliastgutierrez.com/sitemap.xml',
+      'https://www.eliastgutierrez.com/server-sitemap.xml',
     ],
   },
 };
-
-export default config;

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -3,7 +3,7 @@ const withPWA = require('next-pwa');
 const runtimeCaching = require('next-pwa/cache');
 
 /** @type {import('next').NextConfig} */
-const nextConfig = withPWA({
+module.exports = withPWA({
   compiler: {
     styledComponents: true,
   },
@@ -21,5 +21,3 @@ const nextConfig = withPWA({
     skipWaiting: true,
   },
 });
-
-export default nextConfig;

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,8 +1,9 @@
-import withPWA from 'next-pwa';
-import runtimeCaching from 'next-pwa/cache.js';
+/* eslint-disable @typescript-eslint/no-var-requires */
+const withPWA = require('next-pwa');
+const runtimeCaching = require('next-pwa/cache');
 
 /** @type {import('next').NextConfig} */
-const initialNextConfig = {
+const nextConfig = withPWA({
   compiler: {
     styledComponents: true,
   },
@@ -11,10 +12,6 @@ const initialNextConfig = {
     defaultLocale: 'en',
   },
   reactStrictMode: true,
-};
-
-const nextConfig = withPWA({
-  ...initialNextConfig,
   pwa: {
     disable: process.env.NODE_ENV === 'development',
     dest: 'public',

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,6 @@
   "description": "A portfolio website to showcase my skillsets, projects, and written articles. The original version was part of a final project for \"Mobile Friendly Class\" at Bitwise Industries, and the newer version was for my React Apprenticeship.",
   "author": "Elias Gutierrez",
   "private": true,
-  "type": "module",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Changes
1. Removed the `"type"` from `package.json` to avoid Netlify function errors.
2. Changed `next.config.js` and `next-sitemap.js` into non-ECMAScript. 

## Purpose
The `"type"` should be removed from `package.json` since it is crashing the Netlify functions when going to route `https://www.eliastgutierrez.com/server-sitemap.xml`.

Closes #264 