### PR TITLE
Fixed the Site Transition (Web)

### DIFF
--- a/web/components/home/InitialSiteTransition/index.tsx
+++ b/web/components/home/InitialSiteTransition/index.tsx
@@ -1,4 +1,5 @@
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
+import { useAnimation } from 'framer-motion';
 
 import {
   Container,
@@ -17,42 +18,48 @@ interface IInitialSiteTransition {
 
 const InitialSiteTransition: FC<IInitialSiteTransition> = ({
   isFirstMount,
-}) => (
-  <Container
-    onAnimationComplete={() =>
-      document.body.classList.remove('hidden-overflow')
+}) => {
+  const containerControls = useAnimation();
+
+  useEffect(() => {
+    if (!isFirstMount) {
+      containerControls.start('animate');
+
+      const timer = setTimeout(() => {
+        document.body.classList.remove('hidden-overflow');
+      }, 2000);
+
+      return () => clearTimeout(timer);
+    } else {
+      document.body.classList.add('hidden-overflow');
     }
-    {...(!isFirstMount && {
-      animate: {
-        opacity: 0,
-        transition: { duration: 2 },
-      },
-    })}
-  >
-    <Wrapper
-      onAnimationStart={() => document.body.classList.add('hidden-overflow')}
-    >
-      <Svg>
-        <Defs>
-          <LinearGradient1>
-            <Stop offset="0" stopColor="#fff" />
+  }, [isFirstMount, containerControls]);
 
-            <Stop offset="0.35" stopColor="#231f20" />
+  return (
+    <Container animate={containerControls}>
+      <Wrapper>
+        <Svg>
+          <Defs>
+            <LinearGradient1>
+              <Stop offset="0" stopColor="#fff" />
 
-            <Stop offset="1" stopColor="#000" />
-          </LinearGradient1>
+              <Stop offset="0.35" stopColor="#231f20" />
 
-          <LinearGradient2>
-            <Stop offset="0" stopColor="#fff" />
+              <Stop offset="1" stopColor="#000" />
+            </LinearGradient1>
 
-            <Stop offset="1" stopColor="#000" />
-          </LinearGradient2>
-        </Defs>
+            <LinearGradient2>
+              <Stop offset="0" stopColor="#fff" />
 
-        <Polygon />
-      </Svg>
-    </Wrapper>
-  </Container>
-);
+              <Stop offset="1" stopColor="#000" />
+            </LinearGradient2>
+          </Defs>
+
+          <Polygon />
+        </Svg>
+      </Wrapper>
+    </Container>
+  );
+};
 
 export default InitialSiteTransition;

--- a/web/components/home/InitialSiteTransition/styles.ts
+++ b/web/components/home/InitialSiteTransition/styles.ts
@@ -1,7 +1,14 @@
 import styled from 'styled-components';
 import { motion } from 'framer-motion';
 
-export const Container = styled(motion.div)`
+export const Container = styled(motion.div).attrs(() => ({
+  variants: {
+    animate: {
+      opacity: 0,
+      transition: { duration: 2 },
+    },
+  },
+}))`
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
## Changes
1. Changed the functionality on the animation when the `InitialSiteTransition` is running.

## Purpose
On iOS devices and Firefox, when the animation for the `InitialSiteTransition` is finished, the scrollbar should appear. Yet, the scrollbar does not appear most of the time which needs to be fixed.

Closes #267 