### PR TITLE
Fixed Overflow for the Work Logos in Home Page (Web)

### DIFF
--- a/web/components/home/WorkSection/styles.ts
+++ b/web/components/home/WorkSection/styles.ts
@@ -292,8 +292,8 @@ export const WorkImageWrapper = styled(motion.div).attrs(({ className }) => ({
       y: className?.includes('reverse') ? -100 : -150,
     },
     hovering: {
-      rotate: className?.includes('reverse') ? 15 : -15,
-      scale: 1.1,
+      rotate: className?.includes('reverse') ? 5 : -5,
+      scale: 1.01,
       transition: {
         type: 'spring',
         bounce: 0.4,

--- a/web/components/home/WorkSection/styles.ts
+++ b/web/components/home/WorkSection/styles.ts
@@ -323,13 +323,15 @@ export const WorkImageWrapper = styled(motion.div).attrs(({ className }) => ({
     margin-right: 3rem;
 
     @media ${({ theme }) => theme.responsive.below899} {
-      margin-right: 0;
+      margin-right: auto;
+      margin-left: auto;
     }
   }
 
   @media ${({ theme }) => theme.responsive.below899} {
-    width: 100%;
-    margin-left: 0;
+    width: 85%;
+    margin-right: auto;
+    margin-left: auto;
     padding: 1rem 4.5rem;
   }
 


### PR DESCRIPTION
## Changes
1. Decrease the scale and rotation during the animation along with additional styles to avoid the scrollbar in the x-direction.

## Purpose
On the Home page, when the user hovers over the icons in the work section, the scrollbar in the x-direction should not appear. Yet, the scrollbar appears in the x-direction when hovering which should be fixed.

Closes #269 