### PR TITLE
Fix the `margin-top` on Main Container (Web)

### DIFF
--- a/web/common/base/GlobalStyle.tsx
+++ b/web/common/base/GlobalStyle.tsx
@@ -144,7 +144,7 @@ const GlobalStyle = createGlobalStyle`
     margin-top: 10rem;
 
     @media ${({ theme }) => theme.responsive.below599} {
-      margin-top: 5rem;
+      margin-top: 9rem;
     }
   }
 


### PR DESCRIPTION
## Changes
1. Increased the `margin-top` to have good separation between the navbar and main container.

## Purpose
On some responsive devices, the main container holding the content below the navbar should have a good space separation. Instead, the navbar hovers over part of the top main container.

Closes #271 