### PR TITLE
Removed `default_app_config` (API)

### DIFF
--- a/api/article/__init__.py
+++ b/api/article/__init__.py
@@ -1,2 +1,0 @@
-# To identify the default application configuration class
-default_app_config = "article.apps.ArticleConfig"


### PR DESCRIPTION
## Changes
1. Removed deprecation.

## Purpose
Anything with `default_app_config` in `__init__.py` needs to be removed since it is deprecated.

## Learning
[Django 3.2 release notes | Django Documentation](https://docs.djangoproject.com/en/4.0/releases/3.2/#what-s-new-in-django-3-2).

Closes #280 