### PR TITLE
Fixed the Slug Generator (API)

### DIFF
--- a/api/article/models.py
+++ b/api/article/models.py
@@ -192,6 +192,9 @@ def clean(self):
     """
     A custom function to override the ``WagtailAdminModelForm`` ``clean`` function so that
     the ``slug`` field could be created uniquely if it exists in the DB.
+
+    If the user provides a slug whether it is updated or newly created, then
+    the slug would not autogenerate.
     """
 
     cleaned_data = super(WagtailAdminModelForm, self).clean()

--- a/api/article/models.py
+++ b/api/article/models.py
@@ -200,7 +200,7 @@ def clean(self):
         title = cleaned_data.get("title", None)
         slug = cleaned_data.get("slug", None)
 
-        if title:
+        if title and not slug:
             cleaned_data["slug"] = unique_slug_generator(
                 instance=self.instance, new_slug=slug
             )

--- a/api/work/models.py
+++ b/api/work/models.py
@@ -184,7 +184,7 @@ def clean(self):
         title = cleaned_data.get("title", None)
         slug = cleaned_data.get("slug", None)
 
-        if title:
+        if title and not slug:
             cleaned_data["slug"] = unique_slug_generator(
                 instance=self.instance, new_slug=slug
             )

--- a/api/work/models.py
+++ b/api/work/models.py
@@ -176,6 +176,9 @@ def clean(self):
     A custom function to override the ``WagtailAdminModelForm`` ``clean``
     function so that the ``slug`` field could be created uniquely if it exists
     in the DB.
+
+    If the user provides a slug whether it is updated or newly created, then
+    the slug would not autogenerate.
     """
 
     cleaned_data = super(WagtailAdminModelForm, self).clean()


### PR DESCRIPTION
## Changes
1. Added extra conditionals so that the slug would only be autogenerated if it that field is empty.
2. Added extra docs for clarification.

## Purpose
_Describe the problem or feature in addition to a link to the issues._

## Approach
Whenever an existing article/work is updated in Wagtail, the slug should not auto-generate.

Closes #286