### PR TITLE
Fixed Tag Type of Work

### DIFF
--- a/web/app/api/workExtendedApi.ts
+++ b/web/app/api/workExtendedApi.ts
@@ -52,7 +52,7 @@ const workExtendedApi = coreSplitApi.injectEndpoints({
         },
       }),
 
-      providesTags: ['Work'],
+      // providesTags: ['Work'],
     }),
 
     getWorkBySlug: builder.query<IWork, string>({
@@ -65,7 +65,7 @@ const workExtendedApi = coreSplitApi.injectEndpoints({
         },
       }),
 
-      providesTags: ['Work'],
+      // providesTags: ['Work'],
     }),
 
     getSlugsFromWorks: builder.query<TGetSlugsFromWorksResponse, void>({
@@ -78,7 +78,7 @@ const workExtendedApi = coreSplitApi.injectEndpoints({
         },
       }),
 
-      providesTags: ['Work'],
+      // providesTags: ['Work'],
     }),
   }),
 


### PR DESCRIPTION
## Purpose

During production build on Netlify, it was failing due to the non-existent tag type